### PR TITLE
Refactor Cusdis comments for client-side navigation

### DIFF
--- a/docs/assets/cusdis.js
+++ b/docs/assets/cusdis.js
@@ -3,14 +3,24 @@
 
 (function() {
     'use strict';
-    
-    // Wait for DOM to be ready
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initCusdis);
+
+    if (typeof document$ !== 'undefined') {
+        document$.subscribe(() => {
+            removeExistingCusdis();
+            initCusdis();
+        });
     } else {
-        initCusdis();
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => {
+                removeExistingCusdis();
+                initCusdis();
+            });
+        } else {
+            removeExistingCusdis();
+            initCusdis();
+        }
     }
-    
+
     function initCusdis() {
         // Get current page information
         const currentPath = window.location.pathname;
@@ -68,6 +78,23 @@
             };
         }
     }
+
+    function removeExistingCusdis() {
+        const existingThread = document.getElementById('cusdis_thread');
+        if (existingThread) {
+            existingThread.remove();
+        }
+
+        const existingHeading = document.getElementById('comments');
+        if (existingHeading) {
+            existingHeading.remove();
+        }
+
+        const existingScript = document.querySelector('script[src="https://cusdis.com/js/cusdis.es.js"]');
+        if (existingScript) {
+            existingScript.remove();
+        }
+    }
     
     function generatePageId(path) {
         // Remove leading slash and convert to a safe ID
@@ -105,7 +132,9 @@
     }
     
     function addCommentsStyling() {
+        if (document.getElementById('cusdis-style')) return;
         const style = document.createElement('style');
+        style.id = 'cusdis-style';
         style.textContent = `
             /* Main comments container */
             #cusdis_thread {


### PR DESCRIPTION
## Summary
- Reload Cusdis comments after in-page navigation events by subscribing to `document$`
- Remove existing comment containers and script before re-inserting to prevent duplicates
- Avoid duplicate style tags during repeated initialization

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c038fe049c83258fcbf97dd80470eb