### PR TITLE
Pin MkDocs dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
-mkdocs>=1.6
-mkdocs-material[imaging]>=9.5
-mkdocs-minify-plugin>=0.8
-mkdocs-redirects>=1.2
-mkdocs-git-revision-date-localized-plugin>=1.4
-mkdocs-newsletter>=1.1.0
-mkdocs-autolinks-plugin>=0.7.1
-mkdocs-section-index>=0.3.10
+# Pinned dependencies for building the site.
+# To refresh versions, run scripts/update-requirements.sh
+mkdocs==1.6.1
+mkdocs-material[imaging]==9.6.19
+mkdocs-minify-plugin==0.8.0
+mkdocs-redirects==1.2.2
+mkdocs-git-revision-date-localized-plugin==1.4.7
+mkdocs-newsletter==1.1.0
+mkdocs-autolinks-plugin==0.7.1
+mkdocs-section-index==0.3.10

--- a/scripts/update-requirements.sh
+++ b/scripts/update-requirements.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Regenerate requirements.txt with currently installed package versions.
+# Run this after upgrading dependencies with pip.
+
+out_dir="$(cd "$(dirname "$0")/.." && pwd)"
+req_file="$out_dir/requirements.txt"
+
+cat > "$req_file" <<'HEADER'
+# Pinned dependencies for building the site.
+# To refresh versions, run scripts/update-requirements.sh
+HEADER
+
+packages=(
+    mkdocs
+    "mkdocs-material[imaging]"
+    mkdocs-minify-plugin
+    mkdocs-redirects
+    mkdocs-git-revision-date-localized-plugin
+    mkdocs-newsletter
+    mkdocs-autolinks-plugin
+    mkdocs-section-index
+)
+
+for pkg in "${packages[@]}"; do
+    base="${pkg%%[*}"
+    version=$(python - <<PY
+import importlib.metadata, sys
+sys.stdout.write(importlib.metadata.version("${base}"))
+PY
+)
+    echo "${pkg}==${version}" >> "$req_file"
+done
+
+echo "Updated $req_file"


### PR DESCRIPTION
## Summary
- Pin all MkDocs-related dependencies to specific working versions
- Add script to regenerate pinned dependency versions

## Testing
- `pip install -r requirements.txt`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c0390062988325a47c18b046646e66