### PR TITLE
refactor: normalize canonical url

### DIFF
--- a/docs/assets/extra.js
+++ b/docs/assets/extra.js
@@ -39,7 +39,11 @@
         const title = document.title || 'SafeAI-Aus: Australia\'s AI Safety Knowledge Hub';
         const description = document.querySelector('meta[name="description"]')?.content || 
                           'Practical tools, open standards, and trusted guidance for Australian businesses to adopt AI safely';
-        const url = window.location.href;
+        let pathname = window.location.pathname;
+        if (pathname !== '/' && pathname.endsWith('/')) {
+            pathname = pathname.slice(0, -1);
+        }
+        const url = window.location.origin + pathname;
         const image = 'https://safeaiaus.org/assets/safeaiaus-logo-600px.png';
         
         return { title, description, url, image };


### PR DESCRIPTION
## Summary
- ensure getPageData builds canonical URLs from origin and pathname only
- optionally strip trailing slashes for consistency

## Testing
- `mkdocs build`
- `node - <<'NODE' const fs = require('fs'); const {JSDOM} = require('jsdom'); const html = fs.readFileSync('site/about/index.html', 'utf-8'); const dom = new JSDOM(html, {url: 'https://safeaiaus.org/about/?test=1#hash', runScripts: 'outside-only'}); const extraJs = fs.readFileSync('site/assets/extra.js', 'utf-8'); dom.window.eval(extraJs); dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded')); const canonical = dom.window.document.querySelector('link[rel="canonical"]'); console.log('Canonical:', canonical && canonical.href); NODE`
- `find site -name '*.html' -print0 | xargs -0 rg -n '<link rel="canonical" href="[^"]*[?#]' || true`


------
https://chatgpt.com/codex/tasks/task_e_68c03aeb23788325a177f929b058c414