### PR TITLE
Exclude iframe from Cusdis height overrides

### DIFF
--- a/docs/assets/cusdis.js
+++ b/docs/assets/cusdis.js
@@ -253,7 +253,7 @@
             }
             
             /* Fix height constraints on all Cusdis containers */
-            #cusdis_thread * {
+            #cusdis_thread *:not(iframe) {
                 max-height: none !important;
                 overflow: visible !important;
                 height: auto !important;


### PR DESCRIPTION
## Summary
- limit Cusdis universal selector so the iframe retains its natural height

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68c0af5ba3148325ac2003a825b8bbc4