### PR TITLE
Ensure canonical URLs use primary domain

### DIFF
--- a/docs/assets/extra.js
+++ b/docs/assets/extra.js
@@ -34,18 +34,38 @@
         }
     }
     
+    function getCanonicalBase() {
+        const meta = document.querySelector('meta[name="canonical-base"]');
+        if (meta?.content) {
+            return meta.content.replace(/\/+$/, '');
+        }
+
+        const canonicalLink = document.querySelector('link[rel="canonical"]');
+        if (canonicalLink?.href) {
+            try {
+                const canonicalUrl = new URL(canonicalLink.href);
+                return canonicalUrl.origin;
+            } catch (error) {
+                // Ignore invalid canonical link values
+            }
+        }
+
+        return window.location.origin;
+    }
+
     // Get page-specific data from front matter or defaults
     function getPageData() {
         const title = document.title || 'SafeAI-Aus: Australia\'s AI Safety Knowledge Hub';
-        const description = document.querySelector('meta[name="description"]')?.content || 
+        const description = document.querySelector('meta[name="description"]')?.content ||
                           'Practical tools, open standards, and trusted guidance for Australian businesses to adopt AI safely';
         let pathname = window.location.pathname;
         if (pathname !== '/' && pathname.endsWith('/')) {
             pathname = pathname.slice(0, -1);
         }
-        const url = window.location.origin + pathname;
+        const canonicalBase = getCanonicalBase();
+        const url = canonicalBase + pathname;
         const image = 'https://safeaiaus.org/assets/safeaiaus-logo-600px.png';
-        
+
         return { title, description, url, image };
     }
     

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ use_directory_urls: true
 
 theme:
   name: material
+  custom_dir: overrides
   features:
     - navigation.instant
     - navigation.tabs
@@ -47,6 +48,7 @@ theme:
 
 extra:
   # SEO and social media optimization
+  canonical_base: https://safeaiaus.org
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/safeai-aus/safeai-aus.github.io

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block site_meta %}
+  {{ super() }}
+  {% if config.extra.canonical_base %}
+    <meta name="canonical-base" content="{{ config.extra.canonical_base }}">
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add the canonical site base to MkDocs configuration and expose it in the rendered head
- update the extra SEO script to derive URLs from the configured canonical base instead of the runtime host

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68dde21c6ccc832593804ee5538d03cf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use a configured canonical base for all generated URLs and expose it via a template override for the SEO script.
> 
> - **SEO / URL Canonicalization**:
>   - Update `docs/assets/extra.js` to compute `url` from a new `getCanonicalBase()` (prefers `meta[name="canonical-base"]`, falls back to canonical link or `window.location.origin`).
>   - Open Graph/Twitter tags now use canonical-base-derived `og:url`/canonical URL.
> - **MkDocs Configuration**:
>   - Add `extra.canonical_base: https://safeaiaus.org` in `mkdocs.yml`.
>   - Enable `theme.custom_dir: overrides` to allow template overrides.
> - **Template Override**:
>   - New `overrides/main.html` injects `<meta name="canonical-base" ...>` when `config.extra.canonical_base` is set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83458bcb943becadc0a4588d9478f725cac9f407. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->