### PR TITLE
Remove unsafe Object.prototype freeze

### DIFF
--- a/docs/assets/extra.js
+++ b/docs/assets/extra.js
@@ -2,9 +2,6 @@
 (function() {
     'use strict';
     
-    // Security: Prevent prototype pollution and enhance object security
-    Object.freeze(Object.prototype);
-    
     // Umami Cloud Analytics
     (function() {
         const script = document.createElement('script');


### PR DESCRIPTION
## Summary
- delete the Object.freeze(Object.prototype) call from extra.js to avoid breaking MkDocs Material features

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1334d24f083259bd4ae357060f5e3