### PR TITLE
Refine metadata generation and structured data

### DIFF
--- a/docs/assets/extra.js
+++ b/docs/assets/extra.js
@@ -1,33 +1,23 @@
-// SEO and social media optimization for SafeAI-Aus
-(function() {
+// SEO enhancements and structured data helpers for SafeAI-Aus
+(function () {
     'use strict';
-    
-    // Security: Prevent prototype pollution and enhance object security
-    Object.freeze(Object.prototype);
-    
-    // Umami Cloud Analytics
-    (function() {
+
+    // Load Umami Cloud Analytics only once per page.
+    (function loadAnalytics() {
+        if (document.querySelector('script[src="https://cloud.umami.is/script.js"]')) {
+            return;
+        }
         const script = document.createElement('script');
         script.defer = true;
         script.src = 'https://cloud.umami.is/script.js';
         script.setAttribute('data-website-id', 'f228fe92-e13d-456d-92f8-018fac9d587c');
         document.head.appendChild(script);
     })();
-    
-    // Function to add meta tags
-    function addMetaTag(name, content) {
-        if (!document.querySelector(`meta[name="${name}"]`)) {
-            const meta = document.createElement('meta');
-            meta.name = name;
-            meta.content = content;
-            document.head.appendChild(meta);
-        }
-    }
 
     function getRevisionDateISO() {
-        const meta = document.querySelector('meta[name="page:git-revision-date-iso"]');
-        if (meta && meta.content) {
-            return meta.content;
+        const revisionMeta = document.querySelector('meta[name="page:git-revision-date-iso"]');
+        if (revisionMeta?.content) {
+            return revisionMeta.content;
         }
 
         if (typeof window.__SAFEAI_PAGE_REVISION__ === 'string' && window.__SAFEAI_PAGE_REVISION__) {
@@ -36,496 +26,252 @@
 
         return null;
     }
-    
-    // Function to add property meta tags (Open Graph)
-    function addPropertyMetaTag(property, content) {
-        if (!document.querySelector(`meta[property="${property}"]`)) {
-            const meta = document.createElement('meta');
-            meta.setAttribute('property', property);
-            meta.content = content;
-            document.head.appendChild(meta);
-        }
-    }
-    
-    function getCanonicalBase() {
-        const meta = document.querySelector('meta[name="canonical-base"]');
-        if (meta?.content) {
-            return meta.content.replace(/\/+$/, '');
-        }
 
+    function getCanonicalUrl() {
         const canonicalLink = document.querySelector('link[rel="canonical"]');
         if (canonicalLink?.href) {
-            try {
-                const canonicalUrl = new URL(canonicalLink.href);
-                return canonicalUrl.origin;
-            } catch (error) {
-                // Ignore invalid canonical link values
-            }
+            return canonicalLink.href;
         }
-
-        return window.location.origin;
+        try {
+            return window.location.href;
+        } catch (error) {
+            return null;
+        }
     }
 
-    // Get page-specific data from front matter or defaults
-    function getPageData() {
-        const title = document.title || 'SafeAI-Aus: Australia\'s AI Safety Knowledge Hub';
-        const description = document.querySelector('meta[name="description"]')?.content ||
-                          'Practical tools, open standards, and trusted guidance for Australian businesses to adopt AI safely';
-        let pathname = window.location.pathname;
-        if (pathname !== '/' && pathname.endsWith('/')) {
-            pathname = pathname.slice(0, -1);
+    function addJsonLd(id, data) {
+        if (!data || document.getElementById(id)) {
+            return;
         }
-        const canonicalBase = getCanonicalBase();
-        const url = canonicalBase + pathname;
-        const image = 'https://safeaiaus.org/assets/safeaiaus-logo-600px.png';
-
-        return { title, description, url, image };
-    }
-    
-    // Add Open Graph meta tags
-    function addOpenGraphTags() {
-        const data = getPageData();
-        
-        addPropertyMetaTag('og:title', data.title);
-        addPropertyMetaTag('og:description', data.description);
-        addPropertyMetaTag('og:type', 'website');
-        addPropertyMetaTag('og:url', data.url);
-        addPropertyMetaTag('og:image', data.image);
-        addPropertyMetaTag('og:site_name', 'SafeAI-Aus');
-        addPropertyMetaTag('og:locale', 'en_AU');
-    }
-    
-    // Add Twitter Card meta tags
-    function addTwitterCardTags() {
-        const data = getPageData();
-        
-        addMetaTag('twitter:card', 'summary_large_image');
-        addMetaTag('twitter:title', data.title);
-        addMetaTag('twitter:description', data.description);
-        addMetaTag('twitter:image', data.image);
-        addMetaTag('twitter:site', '@safeai_aus');
-        addMetaTag('twitter:creator', '@safeai_aus');
-    }
-    
-    // Add additional SEO meta tags
-    function addSEOTags() {
-        const data = getPageData();
-        
-        // Keywords (if not already present)
-        if (!document.querySelector('meta[name="keywords"]')) {
-            addMetaTag('keywords', 'AI safety, Australian AI standards, AI governance, AI risk assessment, AI compliance, AI safety templates, Australian business AI');
-        }
-        
-        // Author (if not already present)
-        if (!document.querySelector('meta[name="author"]')) {
-            addMetaTag('author', 'SafeAI-Aus');
-        }
-        
-        // Robots (if not already present)
-        if (!document.querySelector('meta[name="robots"]')) {
-            addMetaTag('robots', 'index, follow');
-        }
-        
-        // Canonical URL (if not already present)
-        if (!document.querySelector('link[rel="canonical"]')) {
-            const link = document.createElement('link');
-            link.rel = 'canonical';
-            link.href = data.url;
-            document.head.appendChild(link);
-        }
-    }
-    
-    // Initialize when DOM is ready
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', function() {
-            addOpenGraphTags();
-            addTwitterCardTags();
-            addSEOTags();
-        });
-    } else {
-        addOpenGraphTags();
-        addTwitterCardTags();
-        addSEOTags();
-    }
-    
-    // Add structured data for better search results
-    function addStructuredData() {
-        const currentUrl = window.location.href;
-        
-        // Enhanced organization schema for the main site
-        const structuredData = {
-            "@context": "https://schema.org",
-            "@type": "Organization",
-            "name": "SafeAI-Aus",
-            "url": "https://safeaiaus.org/",
-            "logo": "https://safeaiaus.org/assets/safeaiaus-logo-600px.png",
-            "description": "Australian AI Safety Knowledge Hub — practical tools, open standards, and trusted guidance for responsible AI adoption.",
-            "sameAs": [
-                "https://github.com/safeai-aus/safeai-aus.github.io"
-            ],
-            "foundingDate": "2025",
-            "areaServed": "Australia",
-            "serviceType": "AI Safety Resources",
-            "knowsAbout": [
-                "Artificial Intelligence Safety",
-                "AI Governance",
-                "AI Risk Management",
-                "Australian AI Standards",
-                "AI Compliance",
-                "AI Ethics"
-            ],
-            "hasOfferCatalog": {
-                "@type": "OfferCatalog",
-                "name": "AI Safety Resources",
-                "itemListElement": [
-                    {
-                        "@type": "Offer",
-                        "itemOffered": {
-                            "@type": "Service",
-                            "name": "AI Governance Templates",
-                            "description": "Comprehensive templates for AI policies, risk assessments, and compliance"
-                        }
-                    },
-                    {
-                        "@type": "Offer",
-                        "itemOffered": {
-                            "@type": "Service",
-                            "name": "AI Safety Standards",
-                            "description": "Guidance on Australian AI safety standards and voluntary guardrails"
-                        }
-                    },
-                    {
-                        "@type": "Offer",
-                        "itemOffered": {
-                            "@type": "Service",
-                            "name": "Business Resources",
-                            "description": "Tools, frameworks, and funding information for AI adoption"
-                        }
-                    }
-                ]
-            }
-        };
-        
-        // Add Local Business Schema for better local SEO
-        const localBusinessSchema = {
-            "@context": "https://schema.org",
-            "@type": "LocalBusiness",
-            "name": "SafeAI-Aus",
-            "alternateName": "Safe AI Australia",
-            "description": "Australian AI Safety Knowledge Hub providing practical tools, open standards, and trusted guidance for responsible AI adoption.",
-            "url": "https://safeaiaus.org/",
-            "logo": "https://safeaiaus.org/assets/safeaiaus-logo-600px.png",
-            "image": "https://safeaiaus.org/assets/safeaiaus-logo-600px.png",
-            "address": {
-                "@type": "PostalAddress",
-                "addressCountry": "AU",
-                "addressRegion": "Australia",
-                "addressLocality": "Australia"
-            },
-            "geo": {
-                "@type": "GeoCoordinates",
-                "latitude": "-25.2744",
-                "longitude": "133.7751"
-            },
-            "serviceArea": {
-                "@type": "Country",
-                "name": "Australia"
-            },
-            "areaServed": [
-                {
-                    "@type": "Country",
-                    "name": "Australia"
-                },
-                {
-                    "@type": "State",
-                    "name": "New South Wales"
-                },
-                {
-                    "@type": "State",
-                    "name": "Victoria"
-                },
-                {
-                    "@type": "State",
-                    "name": "Queensland"
-                },
-                {
-                    "@type": "State",
-                    "name": "Western Australia"
-                },
-                {
-                    "@type": "State",
-                    "name": "South Australia"
-                },
-                {
-                    "@type": "State",
-                    "name": "Tasmania"
-                },
-                {
-                    "@type": "State",
-                    "name": "Northern Territory"
-                },
-                {
-                    "@type": "State",
-                    "name": "Australian Capital Territory"
-                }
-            ],
-            "hasOfferCatalog": {
-                "@type": "OfferCatalog",
-                "name": "AI Safety Resources and Services",
-                "itemListElement": [
-                    {
-                        "@type": "Offer",
-                        "itemOffered": {
-                            "@type": "Service",
-                            "name": "AI Governance Templates",
-                            "description": "Comprehensive templates for AI policies, risk assessments, and compliance",
-                            "category": "AI Governance"
-                        }
-                    },
-                    {
-                        "@type": "Offer",
-                        "itemOffered": {
-                            "@type": "Service",
-                            "name": "AI Safety Standards",
-                            "description": "Guidance on Australian AI safety standards and voluntary guardrails",
-                            "category": "AI Safety Standards"
-                        }
-                    },
-                    {
-                        "@type": "Offer",
-                        "itemOffered": {
-                            "@type": "Service",
-                            "name": "Business Resources",
-                            "description": "Tools, frameworks, and funding information for AI adoption",
-                            "category": "Business Resources"
-                        }
-                    },
-                    {
-                        "@type": "Offer",
-                        "itemOffered": {
-                            "@type": "Service",
-                            "name": "AI Risk Assessment",
-                            "description": "Risk assessment checklists and frameworks for AI implementation",
-                            "category": "Risk Management"
-                        }
-                    },
-                    {
-                        "@type": "Offer",
-                        "itemOffered": {
-                            "@type": "Service",
-                            "name": "AI Vendor Evaluation",
-                            "description": "Vendor selection and evaluation criteria for AI solutions",
-                            "category": "Vendor Management"
-                        }
-                    }
-                ]
-            },
-            "knowsAbout": [
-                "Artificial Intelligence Safety",
-                "AI Governance",
-                "AI Risk Management",
-                "Australian AI Standards",
-                "AI Compliance",
-                "AI Ethics",
-                "AI Legislation Australia",
-                "AI Safety Guardrails",
-                "AI Incident Management",
-                "AI Vendor Management"
-            ],
-            "keywords": "AI safety, Australian AI standards, AI governance, AI risk assessment, AI compliance, AI safety templates, Australian business AI, AI safety Australia, AI governance templates, AI risk management",
-            "foundingDate": "2025",
-            "slogan": "Safe AI, Stronger Australia",
-            "contactPoint": {
-                "@type": "ContactPoint",
-                "contactType": "customer service",
-                "availableLanguage": "English",
-                "areaServed": "AU"
-            }
-        };
-        
-        // Add both schemas to the page
-        const schemas = [structuredData, localBusinessSchema];
-        
-        schemas.forEach((schema, index) => {
-            const script = document.createElement('script');
-            script.type = 'application/ld+json';
-            script.textContent = JSON.stringify(schema);
-            script.id = `structured-data-${index}`;
-            document.head.appendChild(script);
-        });
-    }
-    
-    // Add AI-specific structured data
-    function addAISchemaData() {
-        // Get page-specific content
-        const pageTitle = document.querySelector('h1')?.textContent || '';
-        const pageDescription = document.querySelector('meta[name="description"]')?.content || '';
-        const currentUrl = window.location.href;
-        
-        // Determine page type based on URL structure
-        let pageType = "WebPage";
-        let mainEntityType = "TechArticle";
-        
-        if (currentUrl.includes('/governance-templates/')) {
-            pageType = "WebPage";
-            mainEntityType = "TechArticle";
-        } else if (currentUrl.includes('/safety-standards/')) {
-            pageType = "WebPage";
-            mainEntityType = "TechArticle";
-        } else if (currentUrl.includes('/business-resources/')) {
-            pageType = "WebPage";
-            mainEntityType = "TechArticle";
-        }
-        
-        const revisionDateISO = getRevisionDateISO();
-        const fallbackDate = new Date(document.lastModified);
-        const fallbackDateISO = Number.isNaN(fallbackDate.getTime()) ? new Date().toISOString() : fallbackDate.toISOString();
-        const publicationDateISO = revisionDateISO || fallbackDateISO;
-        const modificationDateISO = revisionDateISO || fallbackDateISO;
-
-        const aiSchema = {
-            "@context": "https://schema.org",
-            "@type": pageType,
-            "name": pageTitle,
-            "description": pageDescription,
-            "url": currentUrl,
-            "mainEntity": {
-                "@type": mainEntityType,
-                "headline": pageTitle,
-                "about": {
-                    "@type": "Thing",
-                    "name": "Artificial Intelligence Safety"
-                },
-                "audience": {
-                    "@type": "Audience",
-                    "audienceType": "Australian Businesses"
-                },
-                "keywords": "AI safety, Australian AI standards, AI governance, AI risk assessment, AI compliance",
-                "author": {
-                    "@type": "Organization",
-                    "name": "SafeAI-Aus",
-                    "url": "https://safeaiaus.org/"
-                },
-                "publisher": {
-                    "@type": "Organization",
-                    "name": "SafeAI-Aus",
-                    "url": "https://safeaiaus.org/"
-                },
-                "datePublished": publicationDateISO,
-                "dateModified": modificationDateISO
-            }
-        };
-        
         const script = document.createElement('script');
         script.type = 'application/ld+json';
-        script.textContent = JSON.stringify(aiSchema);
+        script.id = id;
+        script.textContent = JSON.stringify(data);
         document.head.appendChild(script);
     }
-    
-    // Add FAQ schema for pages with FAQ content
+
+    function addOrganizationSchemas() {
+        const path = window.location.pathname.replace(/index\.html$/, '');
+        const isHome = path === '/' || path === '';
+        if (!isHome) {
+            return;
+        }
+
+        const organization = {
+            '@context': 'https://schema.org',
+            '@type': 'Organization',
+            name: 'SafeAI-Aus',
+            url: 'https://safeaiaus.org/',
+            logo: 'https://safeaiaus.org/assets/safeaiaus-logo-600px.png',
+            description: 'Australian AI Safety Knowledge Hub — practical tools, open standards, and trusted guidance for responsible AI adoption.',
+            sameAs: [
+                'https://github.com/safeai-aus/safeai-aus.github.io',
+                'https://twitter.com/safeai_aus'
+            ],
+            foundingDate: '2025',
+            areaServed: 'Australia',
+            knowsAbout: [
+                'Artificial Intelligence Safety',
+                'AI Governance',
+                'AI Risk Management',
+                'Australian AI Standards',
+                'AI Compliance',
+                'AI Ethics'
+            ]
+        };
+
+        const localBusiness = {
+            '@context': 'https://schema.org',
+            '@type': 'LocalBusiness',
+            name: 'SafeAI-Aus',
+            alternateName: 'Safe AI Australia',
+            description: 'Australian AI Safety Knowledge Hub providing practical tools, open standards, and trusted guidance for responsible AI adoption.',
+            url: 'https://safeaiaus.org/',
+            logo: 'https://safeaiaus.org/assets/safeaiaus-logo-600px.png',
+            image: 'https://safeaiaus.org/assets/safeaiaus-logo-600px.png',
+            address: {
+                '@type': 'PostalAddress',
+                addressCountry: 'AU'
+            },
+            areaServed: {
+                '@type': 'Country',
+                name: 'Australia'
+            },
+            serviceArea: {
+                '@type': 'Country',
+                name: 'Australia'
+            }
+        };
+
+        addJsonLd('structured-data-organization', organization);
+        addJsonLd('structured-data-local-business', localBusiness);
+    }
+
+    function addAISchemaData() {
+        const contentContainer = document.querySelector('.md-content');
+        const pageTitle = document.querySelector('h1')?.textContent?.trim();
+        const pageDescription = document.querySelector('meta[name="description"]')?.content?.trim();
+
+        if (!contentContainer || !pageTitle || !pageDescription) {
+            return;
+        }
+
+        const currentUrl = getCanonicalUrl();
+        if (!currentUrl) {
+            return;
+        }
+
+        const revisionDateISO = getRevisionDateISO();
+        const fallbackDate = new Date(document.lastModified);
+        const fallbackISO = Number.isNaN(fallbackDate.getTime()) ? new Date().toISOString() : fallbackDate.toISOString();
+        const datePublished = revisionDateISO || fallbackISO;
+        const dateModified = revisionDateISO || fallbackISO;
+
+        const keywordMeta = document.querySelector('meta[name="keywords"]')?.content || '';
+        const keywords = keywordMeta
+            .split(',')
+            .map((item) => item.trim())
+            .filter((item) => item.length > 0)
+            .slice(0, 10);
+
+        const aiSchema = {
+            '@context': 'https://schema.org',
+            '@type': 'WebPage',
+            name: pageTitle,
+            description: pageDescription,
+            url: currentUrl,
+            mainEntity: {
+                '@type': 'TechArticle',
+                headline: pageTitle,
+                about: {
+                    '@type': 'Thing',
+                    name: 'Artificial Intelligence Safety'
+                },
+                audience: {
+                    '@type': 'Audience',
+                    audienceType: 'Australian Businesses'
+                },
+                keywords: keywords.length ? keywords : undefined,
+                author: {
+                    '@type': 'Organization',
+                    name: 'SafeAI-Aus',
+                    url: 'https://safeaiaus.org/'
+                },
+                publisher: {
+                    '@type': 'Organization',
+                    name: 'SafeAI-Aus',
+                    url: 'https://safeaiaus.org/'
+                },
+                datePublished,
+                dateModified
+            }
+        };
+
+        addJsonLd('structured-data-ai-page', aiSchema);
+    }
+
     function addFAQSchema() {
-        const faqElements = document.querySelectorAll('h3, h4');
+        const faqElements = Array.from(document.querySelectorAll('.md-content h3, .md-content h4'));
         const faqItems = [];
-        
-        faqElements.forEach((element, index) => {
-            if (index < 5) { // Limit to first 5 for schema
-                const question = element.textContent;
-                const nextElement = element.nextElementSibling;
-                let answer = '';
-                
-                if (nextElement && nextElement.tagName === 'P') {
-                    answer = nextElement.textContent;
-                } else if (nextElement && nextElement.tagName === 'UL') {
-                    answer = nextElement.textContent;
+
+        faqElements.forEach((element) => {
+            const question = element.textContent?.trim();
+            if (!question) {
+                return;
+            }
+
+            let answer = '';
+            let next = element.nextElementSibling;
+            while (next && answer === '') {
+                if (next.matches('p, ul, ol')) {
+                    answer = next.textContent.trim();
                 }
-                
-                if (answer) {
-                    faqItems.push({
-                        "@type": "Question",
-                        "name": question,
-                        "acceptedAnswer": {
-                            "@type": "Answer",
-                            "text": answer
-                        }
-                    });
-                }
+                next = next.nextElementSibling;
+            }
+
+            if (answer) {
+                faqItems.push({
+                    '@type': 'Question',
+                    name: question,
+                    acceptedAnswer: {
+                        '@type': 'Answer',
+                        text: answer
+                    }
+                });
             }
         });
-        
-        if (faqItems.length > 0) {
-            const faqSchema = {
-                "@context": "https://schema.org",
-                "@type": "FAQPage",
-                "mainEntity": faqItems
-            };
-            
-            const script = document.createElement('script');
-            script.type = 'application/ld+json';
-            script.textContent = JSON.stringify(faqSchema);
-            document.head.appendChild(script);
+
+        if (faqItems.length === 0) {
+            return;
         }
+
+        const schema = {
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: faqItems.slice(0, 5)
+        };
+
+        addJsonLd('structured-data-faq', schema);
     }
-    
-    // Add HowTo schema for template and checklist pages
+
     function addHowToSchema() {
-        const currentUrl = window.location.href;
-        
-        if (currentUrl.includes('/governance-templates/') || currentUrl.includes('/checklist')) {
-            const pageTitle = document.querySelector('h1')?.textContent || '';
-            const pageDescription = document.querySelector('meta[name="description"]')?.content || '';
-            
-            const howToSchema = {
-                "@context": "https://schema.org",
-                "@type": "HowTo",
-                "name": pageTitle,
-                "description": pageDescription,
-                "about": {
-                    "@type": "Thing",
-                    "name": "AI Safety Implementation"
-                },
-                "audience": {
-                    "@type": "Audience",
-                    "audienceType": "Australian Businesses"
-                },
-                "step": [
-                    {
-                        "@type": "HowToStep",
-                        "name": "Review Template",
-                        "text": "Review the provided template structure and requirements"
-                    },
-                    {
-                        "@type": "HowToStep",
-                        "name": "Customize Content",
-                        "text": "Adapt the template to your organization's specific needs"
-                    },
-                    {
-                        "@type": "HowToStep",
-                        "name": "Implement",
-                        "text": "Apply the template in your AI governance framework"
-                    }
-                ]
-            };
-            
-            const script = document.createElement('script');
-            script.type = 'application/ld+json';
-            script.textContent = JSON.stringify(howToSchema);
-            document.head.appendChild(script);
+        const path = window.location.pathname;
+        const isTemplate = /governance-templates\//.test(path) || /checklist/.test(path);
+        if (!isTemplate) {
+            return;
         }
+
+        const pageTitle = document.querySelector('h1')?.textContent?.trim();
+        const pageDescription = document.querySelector('meta[name="description"]')?.content?.trim();
+        if (!pageTitle || !pageDescription) {
+            return;
+        }
+
+        const howToSchema = {
+            '@context': 'https://schema.org',
+            '@type': 'HowTo',
+            name: pageTitle,
+            description: pageDescription,
+            about: {
+                '@type': 'Thing',
+                name: 'AI Safety Implementation'
+            },
+            audience: {
+                '@type': 'Audience',
+                audienceType: 'Australian Businesses'
+            },
+            step: [
+                {
+                    '@type': 'HowToStep',
+                    name: 'Review Template',
+                    text: 'Review the provided template structure and requirements.'
+                },
+                {
+                    '@type': 'HowToStep',
+                    name: 'Customise Content',
+                    text: 'Adapt the template to your organisation’s specific needs.'
+                },
+                {
+                    '@type': 'HowToStep',
+                    name: 'Implement',
+                    text: 'Apply the template within your AI governance framework.'
+                }
+            ]
+        };
+
+        addJsonLd('structured-data-howto', howToSchema);
     }
-    
-    // Add structured data when page loads
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', function() {
-            addStructuredData();
-            addAISchemaData();
-            addFAQSchema();
-            addHowToSchema();
-        });
-    } else {
-        addStructuredData();
+
+    function initialiseStructuredData() {
+        addOrganizationSchemas();
         addAISchemaData();
         addFAQSchema();
         addHowToSchema();
     }
-    
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initialiseStructuredData);
+    } else {
+        initialiseStructuredData();
+    }
 })();

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,21 +1,15 @@
 ---
-layout: page
 title: "SafeAI-Aus: Australia's AI Safety Knowledge Hub"
 description: "Practical tools, open standards, and trusted guidance for Australian businesses to adopt AI safely and responsibly. Free AI governance templates, risk assessments, and compliance checklists."
 keywords: "AI safety, Australian AI standards, AI governance, AI risk assessment, AI compliance, AI safety templates, Australian business AI, AI safety Australia, AI governance templates, AI risk management"
 author: "SafeAI-Aus"
-robots: "index, follow"
 og_title: "SafeAI-Aus: Australia's AI Safety Knowledge Hub"
 og_description: "Practical tools, open standards, and trusted guidance for Australian businesses to adopt AI safely"
-og_type: "website"
 og_url: "https://safeaiaus.org/"
 og_image: "assets/safeaiaus-logo-600px.png"
-twitter_card: "summary_large_image"
 twitter_title: "SafeAI-Aus: Australia's AI Safety Knowledge Hub"
 twitter_description: "Practical tools, open standards, and trusted guidance for Australian businesses to adopt AI safely"
 canonical_url: "https://safeaiaus.org/"
-permalink: /
-security: "high"
 ---
 > Open-source Australian knowledge hub for safe, responsible, and growth-focused AI adoption in business.
 

--- a/overrides/partials/head.html
+++ b/overrides/partials/head.html
@@ -1,7 +1,100 @@
 {{ super() }}
-{% if page and page.meta and page.meta.git_revision_date_localized %}
-  {% set revision = page.meta.git_revision_date_localized %}
-  {% set iso = page.meta.git_revision_date_localized_raw_iso_datetime | default(None, true) %}
+
+{% set meta = page.meta if page and page.meta else {} %}
+{% set site_url = config.site_url.rstrip('/') if config.site_url else None %}
+
+{# -- Canonical URL ------------------------------------------------------- #}
+{% if page and page.canonical_url %}
+  {% set canonical = page.canonical_url %}
+{% elif meta.canonical_url %}
+  {% set canonical = meta.canonical_url %}
+{% elif site_url and page and page.url %}
+  {% set canonical = site_url ~ '/' ~ page.url.lstrip('/') %}
+{% else %}
+  {% set canonical = None %}
+{% endif %}
+
+{% if canonical %}
+  <link rel="canonical" href="{{ canonical | e }}">
+{% endif %}
+
+{# -- Basic metadata ------------------------------------------------------ #}
+{% set title = meta.og_title or meta.title or page.title or config.site_name %}
+{% set description = meta.og_description or meta.description or config.site_description %}
+{% set robots = meta.robots or 'index, follow' %}
+{% set keywords = meta.keywords %}
+{% set author = meta.author or config.site_author %}
+
+{% if description %}
+  <meta name="description" content="{{ description | e }}">
+{% endif %}
+{% if author %}
+  <meta name="author" content="{{ author | e }}">
+{% endif %}
+{% if robots %}
+  <meta name="robots" content="{{ robots | e }}">
+{% endif %}
+{% if keywords %}
+  <meta name="keywords" content="{{ keywords | e }}">
+{% endif %}
+
+{# -- Open Graph metadata ------------------------------------------------- #}
+{% set og_type = meta.og_type or 'website' %}
+{% if canonical %}
+  {% set og_url = meta.og_url or canonical %}
+{% elif meta.og_url %}
+  {% set og_url = meta.og_url %}
+{% else %}
+  {% set og_url = None %}
+{% endif %}
+{% set image = meta.og_image %}
+{% if image and site_url and not image.startswith('http') %}
+  {% set image = site_url ~ '/' ~ image.lstrip('/') %}
+{% endif %}
+{% if not image and site_url and config.theme.logo %}
+  {% set image = site_url ~ '/' ~ config.theme.logo.lstrip('/') %}
+{% endif %}
+
+<meta property="og:site_name" content="{{ config.site_name | e }}">
+<meta property="og:title" content="{{ title | e }}">
+{% if description %}
+  <meta property="og:description" content="{{ description | e }}">
+{% endif %}
+<meta property="og:type" content="{{ og_type | e }}">
+{% if og_url %}
+  <meta property="og:url" content="{{ og_url | e }}">
+{% endif %}
+{% if image %}
+  <meta property="og:image" content="{{ image | e }}">
+{% endif %}
+
+{# -- Twitter metadata ---------------------------------------------------- #}
+{% set twitter_card = meta.twitter_card or 'summary_large_image' %}
+{% set twitter_title = meta.twitter_title or title %}
+{% set twitter_description = meta.twitter_description or description %}
+{% set twitter_image = meta.twitter_image or image %}
+{% set twitter_site = meta.twitter_site or '@safeai_aus' %}
+{% set twitter_creator = meta.twitter_creator or twitter_site %}
+
+<meta name="twitter:card" content="{{ twitter_card | e }}">
+<meta name="twitter:title" content="{{ twitter_title | e }}">
+{% if twitter_description %}
+  <meta name="twitter:description" content="{{ twitter_description | e }}">
+{% endif %}
+{% if twitter_image %}
+  <meta name="twitter:image" content="{{ twitter_image | e }}">
+{% endif %}
+{% if twitter_site %}
+  <meta name="twitter:site" content="{{ twitter_site | e }}">
+{% endif %}
+{% if twitter_creator %}
+  <meta name="twitter:creator" content="{{ twitter_creator | e }}">
+{% endif %}
+
+{# -- Git revision metadata (used by custom scripts) ---------------------- #}
+{% if meta.git_revision_date_localized %}
+  {% set revision = meta.git_revision_date_localized %}
+  {% set iso = meta.git_revision_date_localized_raw_iso_datetime | default(None, true) %}
   {% if iso %}
     {% set iso = iso | replace(' ', 'T') %}
     {% if 'T' in iso %}
@@ -11,7 +104,7 @@
       {% endif %}
     {% endif %}
   {% else %}
-    {% set iso = page.meta.git_revision_date_localized_raw_iso_date | default(None, true) %}
+    {% set iso = meta.git_revision_date_localized_raw_iso_date | default(None, true) %}
   {% endif %}
   {% if iso is none %}
     {% if revision is string %}


### PR DESCRIPTION
## Summary
- render canonical, social, and descriptive meta tags server-side from MkDocs page metadata to eliminate runtime duplication
- tidy the home page front matter so only MkDocs-aware SEO fields remain
- rework the custom extra.js to scope analytics and JSON-LD output to relevant pages without injecting duplicate tags

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68e133a322a4832598529bbfef9d811b