### PR TITLE
Follow-up: ensure robots meta tag respects Material defaults

### DIFF
--- a/overrides/partials/head.html
+++ b/overrides/partials/head.html
@@ -21,12 +21,16 @@
 {# -- Basic metadata ------------------------------------------------------ #}
 {% set title = meta.og_title or meta.title or page.title or config.site_name %}
 {% set description = meta.og_description or meta.description or config.site_description %}
+{% set robots = none %}
+{% set robots_explicit = false %}
 {% if meta.get is defined %}
-  {% set robots = meta.get('robots') %}
+  {% if 'robots' in meta %}
+    {% set robots = meta.get('robots') %}
+    {% set robots_explicit = true %}
+  {% endif %}
 {% elif meta.robots is defined %}
   {% set robots = meta.robots %}
-{% else %}
-  {% set robots = none %}
+  {% set robots_explicit = true %}
 {% endif %}
 {% set keywords = meta.keywords %}
 {% set author = meta.author or config.site_author %}
@@ -37,7 +41,7 @@
 {% if author %}
   <meta name="author" content="{{ author | e }}">
 {% endif %}
-{% if robots is not none %}
+{% if robots_explicit and robots is not none %}
   <meta name="robots" content="{{ robots | e }}">
 {% endif %}
 {% if keywords %}


### PR DESCRIPTION
## Summary
- update the head override to track whether a robots directive was explicitly provided in page metadata
- only emit a robots meta tag when a page defines one so Material's default noindex tags remain authoritative

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68f4e5ec05fc832596a90c9688fd6f5f