### PR TITLE
Add heading hierarchy validator and fix inconsistencies

### DIFF
--- a/docs/business-resources/ai-learning-development-directory.md
+++ b/docs/business-resources/ai-learning-development-directory.md
@@ -116,7 +116,9 @@ Each resource includes details on **format, eligibility, cost, and difficulty le
 
 ## Open-Source / Creative Commons Programs
 
-#### 8. [MIT OpenCourseWare – AI & ML Courses](https://ocw.mit.edu)  
+### Global & Open Access Courses
+
+#### 8. [MIT OpenCourseWare – AI & ML Courses](https://ocw.mit.edu)
 *MIT*
 
 - **Description:** Deep-dive curriculum including lectures, notes, and problem sets on foundational AI and ML techniques.  

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -171,7 +171,7 @@ Assessing third-party AI tools for security, privacy, reliability and compliance
 
 ---
 
-# 🔗 Related Resources
+## 🔗 Related Resources
 - [Template Library](governance-templates/policy-template-library.md)  
 - [AI Safety Standards (Australia & International)](safety-standards/voluntary-ai-safety-standard-10-guardrails.md)  
 - [AI Project Register](governance-templates/ai-project-register.md)  

--- a/docs/governance-templates/ai-incident-report-form.md
+++ b/docs/governance-templates/ai-incident-report-form.md
@@ -31,7 +31,7 @@ Use this form whenever an AI-related incident occurs in your business. The infor
 
 ---
 
-# AI Incident Report Form (Template)
+## AI Incident Report Form (Template)
 
 **Date of Report:** ____________________  
 **Reported By:** ____________________  
@@ -46,7 +46,7 @@ Severity Definitions:
 - Medium: Limited impact, workaround available  
 - Low: Minor issue, minimal impact  
 
-## 1. Incident ID & Date
+### 1. Incident ID & Date
 Incident identification number and date/time of occurrence  
 ☐ Evidence attached
 
@@ -57,19 +57,19 @@ Reporting Timeline:
 [ ] Within 24 hours (High)  
 [ ] Within 72 hours (Medium/Low)  
 
-## 2. Reporter Details
+### 2. Reporter Details
 Name, role, and contact information of person reporting the incident  
 ☐ Evidence attached
 
-## 3. AI System Details
+### 3. AI System Details
 System name, version, vendor, and deployment environment  
 ☐ Evidence attached
 
-## 4. Incident Description
+### 4. Incident Description
 Description of what happened, including inputs, outputs, and observed issues  
 ☐ Evidence attached
 
-## 5. Impact Assessment
+### 5. Impact Assessment
 Actual or potential harm (individuals, organisation, or public).  
 ☐ Evidence attached
 
@@ -78,27 +78,27 @@ Estimated Financial Impact: $__________
 Regulatory Reporting Required: [ ] Yes  [ ] No  [ ] Under Review  
 Media/Reputation Risk: [ ] High  [ ] Medium  [ ] Low  [ ] None  
 
-## 6. Data Involved
+### 6. Data Involved
 Personal data, sensitive information, or intellectual property affected  
 ☐ Evidence attached
 
-## 7. Immediate Actions Taken
+### 7. Immediate Actions Taken
 Containment, mitigation, or workaround steps.  
 ☐ Evidence attached
 
-## 8. Root Cause (if known)
+### 8. Root Cause (if known)
 Likely cause (e.g., model error, data bias, misuse)  
 ☐ Evidence attached
 
-## 9. Follow-up Actions
+### 9. Follow-up Actions
 Steps to prevent recurrence or improve safeguards.  
 ☐ Evidence attached
 
-## 10. Review & Approval
+### 10. Review & Approval
 Reviewer/approver name, role, and signature  
 ☐ Evidence attached
 
-## 11. Lessons Learned
+### 11. Lessons Learned
 What worked well in the response: __________  
 What could be improved: __________  
 Preventive measures identified: __________  
@@ -131,9 +131,9 @@ This form aligns with:
 
 ---
 
-# Template Disclaimer & Licence
+## Template Disclaimer & Licence
 
-## Disclaimer
+### Disclaimer
 The purpose of this template is to provide best practice guidance on implementing safe and responsible AI governance in Australian organisations.   
 
 SafeAI-Aus has exercised care and skill in the preparation of this material. However, SafeAI-Aus does not guarantee the accuracy, reliability, or completeness of the information contained. 
@@ -144,7 +144,7 @@ This publication does not indicate any commitment by SafeAI-Aus to a particular 
 
 ---
 
-## Licence
+### Licence
 This template is made available under the **Creative Commons Attribution 4.0 International (CC BY 4.0)** licence.  
 
 You are free to: 

--- a/docs/governance-templates/ai-project-register.md
+++ b/docs/governance-templates/ai-project-register.md
@@ -35,9 +35,9 @@ This register provides a structured way to maintain a central record of all AI i
 
 ---
 
-# AI Project Register Template (Template)
+## AI Project Register Template (Template)
 
-## Project Register Fields  
+### Project Register Fields
 
 | Section | Field | Description | Example Entry |
 |---------|-------|-------------|---------------|
@@ -109,9 +109,9 @@ Health Indicators:
 
 ---
 
-# Template Disclaimer & Licence
+## Template Disclaimer & Licence
 
-## Disclaimer
+### Disclaimer
 The purpose of this template is to provide best practice guidance on implementing safe and responsible AI governance in Australian organisations.   
 
 SafeAI-Aus has exercised care and skill in the preparation of this material. However, SafeAI-Aus does not guarantee the accuracy, reliability, or completeness of the information contained. 
@@ -122,7 +122,7 @@ This publication does not indicate any commitment by SafeAI-Aus to a particular 
 
 ---
 
-## Licence
+### Licence
 This template is made available under the **Creative Commons Attribution 4.0 International (CC BY 4.0)** licence.  
 
 You are free to:  

--- a/docs/governance-templates/ai-readiness-checklist.md
+++ b/docs/governance-templates/ai-readiness-checklist.md
@@ -85,9 +85,9 @@ Tick the boxes that apply to your organisation. A higher score means greater rea
 
 ---
 
-# Template Disclaimer & Licence
+## Template Disclaimer & Licence
 
-## Disclaimer
+### Disclaimer
 The purpose of this template is to provide best practice guidance on implementing safe and responsible AI governance in Australian organisations.   
 
 SafeAI-Aus has exercised care and skill in the preparation of this material. However, SafeAI-Aus does not guarantee the accuracy, reliability, or completeness of the information contained. 
@@ -98,7 +98,7 @@ This publication does not indicate any commitment by SafeAI-Aus to a particular 
 
 ---
 
-## Licence
+### Licence
 This template is made available under the **Creative Commons Attribution 4.0 International (CC BY 4.0)** licence.  
 
 You are free to:  

--- a/docs/governance-templates/ai-risk-assessment-checklist.md
+++ b/docs/governance-templates/ai-risk-assessment-checklist.md
@@ -190,9 +190,9 @@ Additional considerations for risk level:
 
 ---
 
-# Template Disclaimer & Licence
+## Template Disclaimer & Licence
 
-## Disclaimer
+### Disclaimer
 The purpose of this template is to provide best practice guidance on implementing safe and responsible AI governance in Australian organisations.   
 
 SafeAI-Aus has exercised care and skill in the preparation of this material. However, SafeAI-Aus does not guarantee the accuracy, reliability, or completeness of the information contained. 
@@ -203,7 +203,7 @@ This publication does not indicate any commitment by SafeAI-Aus to a particular 
 
 ---
 
-## Licence
+### Licence
 This template is made available under the **Creative Commons Attribution 4.0 International (CC BY 4.0)** licence.  
 
 You are free to:  

--- a/docs/governance-templates/ai-risk-register.md
+++ b/docs/governance-templates/ai-risk-register.md
@@ -92,9 +92,9 @@ The risk register process is not just a compliance exercise — it is a practica
 
 ---
 
-# Template Disclaimer & Licence
+## Template Disclaimer & Licence
 
-## Disclaimer
+### Disclaimer
 The purpose of this template is to provide best practice guidance on implementing safe and responsible AI governance in Australian organisations.   
 
 SafeAI-Aus has exercised care and skill in the preparation of this material. However, SafeAI-Aus does not guarantee the accuracy, reliability, or completeness of the information contained. 
@@ -105,7 +105,7 @@ This publication does not indicate any commitment by SafeAI-Aus to a particular 
 
 ---
 
-## Licence
+### Licence
 This template is made available under the **Creative Commons Attribution 4.0 International (CC BY 4.0)** licence.  
 
 You are free to:  

--- a/docs/governance-templates/ai-use-policy.md
+++ b/docs/governance-templates/ai-use-policy.md
@@ -26,7 +26,7 @@ This page provides a reusable **AI Use Policy** for Australian businesses seekin
 
 ---
 
-# AI Use Policy (Template)
+## AI Use Policy (Template)
 
 **Effective date:** [Insert Date]  
 **Review cycle:** [e.g. Annually]  
@@ -34,7 +34,7 @@ This page provides a reusable **AI Use Policy** for Australian businesses seekin
 
 ---
 
-## 1. Purpose
+### 1. Purpose
 The purpose of this policy is to ensure the safe, responsible, and effective use of Artificial Intelligence (AI) within [Organisation Name]. It establishes clear expectations for how AI should support organisational goals, protect people, and align with applicable standards and laws.  
 
 This policy aims to: 
@@ -47,7 +47,7 @@ This policy aims to:
 
 ---
 
-## 2. Scope
+### 2. Scope
 This policy applies across the organisation wherever AI technologies are developed, purchased, or used. It covers both internal and external use cases, ensuring that all applications of AI are appropriately governed.  
 
 In scope are:  
@@ -58,7 +58,7 @@ In scope are:
 
 ---
 
-## 3. Terms & Definitions
+### 3. Terms & Definitions
 To ensure consistency and clarity, the following definitions apply within this policy:  
 
 - **Artificial Intelligence (AI):** Computer systems that perform tasks normally requiring human intelligence (e.g., text generation, decision support).  
@@ -70,7 +70,7 @@ To ensure consistency and clarity, the following definitions apply within this p
 
 ---
 
-## 4. Principles
+### 4. Principles
 The organisation is committed to using AI in a way that is safe, transparent, and aligned with community expectations. All AI systems and services must reflect the following principles:  
 
 - Have a clear purpose and benefit.  
@@ -86,7 +86,7 @@ The organisation is committed to using AI in a way that is safe, transparent, an
 
 ---
 
-## 5. Acceptable Use
+### 5. Acceptable Use
 AI technologies may be used where they support the organisation’s objectives, comply with relevant laws, and can be applied responsibly. Acceptable use requires staff to follow the conditions below:  
 
 - Align AI use with organisational goals and policies.  
@@ -98,7 +98,7 @@ AI technologies may be used where they support the organisation’s objectives, 
 
 ---
 
-## 6. Prohibited Use
+### 6. Prohibited Use
 To manage risks and maintain compliance, certain uses of AI are not permitted under any circumstances. These restrictions help safeguard the organisation and its stakeholders.  
 
 The following are strictly prohibited: 
@@ -111,7 +111,7 @@ The following are strictly prohibited:
 
 ---
 
-## 7. Privacy, Intellectual Property & Data Rights
+### 7. Privacy, Intellectual Property & Data Rights
 Respecting privacy and protecting intellectual property is central to responsible AI adoption. AI use must safeguard both personal information and organisational assets, while also respecting the rights of third parties.  
 
 The organisation requires that: 
@@ -123,7 +123,7 @@ The organisation requires that:
 
 ---
 
-## 8. Environmental & Sustainability Considerations
+### 8. Environmental & Sustainability Considerations
 The organisation commits to considering the environmental impact of AI systems:
 
 - Energy consumption of AI models will be monitored  
@@ -133,7 +133,7 @@ The organisation commits to considering the environmental impact of AI systems:
 
 ---
 
-## 9. Roles & Responsibilities
+### 9. Roles & Responsibilities
 Effective governance requires clear accountabilities. Different roles within the organisation carry specific responsibilities for AI oversight and use.  
 
 - **Board/Executive:** Provide oversight of AI risk and ensure alignment to strategy.  
@@ -146,14 +146,14 @@ Effective governance requires clear accountabilities. Different roles within the
 
 ---
 
-## 10. Compliance & Review
+### 10. Compliance & Review
 Compliance with this policy is mandatory. Breaches will be addressed in line with organisational disciplinary procedures or contractual terms.  
 
 This policy will be reviewed at least annually, or sooner if required by law, organisational change, or updates to standards (e.g. ISO/IEC 42001:2023).  
 
 ---
 
-## 11. Related Standards & References
+### 11. Related Standards & References
 This policy is guided by relevant standards and legislation that inform responsible AI practice. These include:  
 
 - Australian Government Voluntary AI Safety Standard (2024) – 10 Guardrails  
@@ -165,7 +165,7 @@ This policy is guided by relevant standards and legislation that inform responsi
 
 ---
 
-## 12. Quick Guide – Do’s & Don’ts
+### 12. Quick Guide – Do’s & Don’ts
 To support day-to-day use, the following quick guide summarises acceptable and unacceptable practices:  
 
 **Do:**  
@@ -201,9 +201,9 @@ Common Scenarios:
 
 ---
 
-# Template Disclaimer & Licence
+## Template Disclaimer & Licence
 
-## Disclaimer
+### Disclaimer
 The purpose of this template is to provide best practice guidance on implementing safe and responsible AI governance in Australian organisations.   
 
 SafeAI-Aus has exercised care and skill in the preparation of this material. However, SafeAI-Aus does not guarantee the accuracy, reliability, or completeness of the information contained. 
@@ -214,7 +214,7 @@ This publication does not indicate any commitment by SafeAI-Aus to a particular 
 
 ---
 
-## Licence
+### Licence
 This AI Use Policy template is made available under the **Creative Commons Attribution 4.0 International (CC BY 4.0)** licence.  
 
 You are free to:  

--- a/docs/governance-templates/ai-vendor-evaluation-checklist.md
+++ b/docs/governance-templates/ai-vendor-evaluation-checklist.md
@@ -35,13 +35,13 @@ This checklist can be used as part of your organisation’s AI governance framew
 Work through each section, seek evidence from the vendor, and record your findings. Where needed, consult legal, risk, or IT experts before approving an AI vendor.  
 
 ---
-# AI Vendor Evaluation Checklist (Template)
+## AI Vendor Evaluation Checklist (Template)
 
 **Vendor Name:** ____________________  
 **Product/Service:** ____________________  
 **Date of Evaluation:** ____________________  
 
-## Vendor Evaluation Summary (Quick Scoring Table)
+### Vendor Evaluation Summary (Quick Scoring Table)
 
 | Category                   | Score (1–5) | Notes / Evidence |
 |-----------------------------|-------------|------------------|
@@ -74,49 +74,49 @@ Additional Evaluation Criteria:
 
 ---
 
-## 1. Vendor Information
+### 1. Vendor Information
 Record vendor details including name, ABN/ACN, headquarters, key contacts, and years in operation.  
 *Sources: ASIC requirements; Supplier Due Diligence Standards*  
 
-## 2. Product/Service Description
+### 2. Product/Service Description
 Outline the AI products or services provided, including version numbers and intended use.  
 *Sources: Guardrail 1; Australian AI Ethics Principle: Transparency*  
 
-## 3. Compliance & Certifications
+### 3. Compliance & Certifications
 List certifications (ISO/IEC 23894, ISO/IEC 42001, SOC 2) and confirm regulatory compliance.  
 *Sources: Guardrail 7; ISO/IEC 42001*  
 
-## 4. Data Governance
+### 4. Data Governance
 Check vendor policies on data handling, privacy protection, IP safeguards, and data provenance.  
 *Sources: Privacy Act 1988 (APPs); Guardrails 4 & 7*  
 
-## 5. Security Practices
+### 5. Security Practices
 Assess cybersecurity measures, vulnerability management, and penetration testing frequency.  
 *Sources: Guardrail 5; ACSC Essential Eight*  
 
-## 6. Model Development & Testing
+### 6. Model Development & Testing
 Request information on training data, bias mitigation, validation, and explainability features.  
 *Sources: Guardrails 6 & 9; NIST AI RMF*  
 
-## 7. Human Oversight & Support
+### 7. Human Oversight & Support
 Review the level of human oversight in operations, escalation paths, and customer support availability.  
 *Sources: Guardrail 8; Australian AI Ethics Principle: Accountability*  
 
-## 8. Incident Management
+### 8. Incident Management
 Confirm the vendor’s process for incident reporting, investigation, and resolution timelines.  
 *Sources: Guardrail 10; ISO/IEC 27035*  
 
-## 9. Contractual Safeguards
+### 9. Contractual Safeguards
 Review liability clauses, service-level agreements, IP ownership terms, and termination rights.  
 *Sources: Australian Consumer Law; Contract Law*  
 
-## 10. References & Track Record
+### 10. References & Track Record
 Check customer references, case studies, and the vendor’s history of regulatory compliance.  
 *Sources: Supplier Risk Management Best Practice*  
 
 ---
 
-## Documenting & Storing Results
+### Documenting & Storing Results
 To ensure accountability and provide an audit trail:  
 
 - Record all responses and supporting evidence provided by the vendor.  
@@ -126,28 +126,28 @@ To ensure accountability and provide an audit trail:
 - Cross-reference this checklist with your organisation’s AI Risk Assessment and Incident Reporting processes for a complete governance record.  
 
 ---
-## 11. Financial & Commercial Assessment
+### 11. Financial & Commercial Assessment
 - Vendor financial health verified (credit check, annual reports)  
 - Total cost of ownership calculated (licensing, implementation, maintenance)  
 - ROI projections documented  
 - Payment terms and conditions reviewed  
 - Penalties for non-performance defined  
 
-## 12. Technical Integration
+### 12. Technical Integration
 - API documentation quality and completeness  
 - Compatibility with existing systems verified  
 - Data migration requirements assessed  
 - Performance benchmarks established  
 - Scalability limitations understood  
 
-## Automatic Disqualifiers (Red Flags)
+### Automatic Disqualifiers (Red Flags)
 [ ] No evidence of data protection measures  
 [ ] Unwilling to provide security certifications  
 [ ] No liability acceptance in contracts  
 [ ] Previous regulatory violations  
 [ ] Inability to demonstrate compliance with Australian law  
 
-## Proof of Concept / Pilot Phase
+### Proof of Concept / Pilot Phase
 [ ] Pilot success criteria defined  
 [ ] Limited data set for testing prepared  
 [ ] Evaluation timeline established (typically 30–90 days)  
@@ -160,9 +160,9 @@ To ensure accountability and provide an audit trail:
 
 ---
 
-# Template Disclaimer & Licence
+## Template Disclaimer & Licence
 
-## Disclaimer
+### Disclaimer
 The purpose of this template is to provide best practice guidance on implementing safe and responsible AI governance in Australian organisations.   
 
 SafeAI-Aus has exercised care and skill in the preparation of this material. However, SafeAI-Aus does not guarantee the accuracy, reliability, or completeness of the information contained. 
@@ -173,7 +173,7 @@ This publication does not indicate any commitment by SafeAI-Aus to a particular 
 
 ---
 
-## Licence
+### Licence
 This template is made available under the **Creative Commons Attribution 4.0 International (CC BY 4.0)** licence.  
 
 You are free to:  

--- a/docs/newsletter/0_newsletter_index.md
+++ b/docs/newsletter/0_newsletter_index.md
@@ -25,10 +25,10 @@ Stay informed with news, resources, and practical tools on safe and responsible 
 
 If you want to follow the meaningful changes of this site, you can either:
 
-* [Subscribe to the RSS feed](#rss_feed)
-* [Browse the Newsletter section](#newsletter_section)
+* [Subscribe to the RSS feed](#rss-feed)
+* [Browse the Newsletter section](#newsletter-section)
 
-# RSS feed
+## RSS feed
 
 You can choose how often you want to see the site updates:
 
@@ -37,12 +37,12 @@ You can choose how often you want to see the site updates:
 * [Monthly](https://safeaiaus.org/monthly.xml)
 * [Yearly](https://safeaiaus.org/yearly.xml)
 
-# Newsletter section
+## Newsletter section
 
 We aggregate the changes by year, month, week and day. You can navigate this section to
 see the latest changes.
 
-# Credits
+## Credits
 
 The newsletters and the RSS feeds are automatically created from the message commits of
 the repository thanks to the

--- a/docs/safety-standards/ai-australian-legislation.md
+++ b/docs/safety-standards/ai-australian-legislation.md
@@ -22,7 +22,7 @@ While Australia doesn’t yet have AI-specific legislation, AI use is already go
 
 As of August 2025, the Government is also considering new AI-specific regulation, including mandatory guardrails for high-risk applications, but outcomes remain politically uncertain.  
 
-### Why this matters
+## Why this matters
 Understanding the current legal landscape helps organisations:  
 
 - Avoid legal and reputational risks from misuse of AI  

--- a/docs/safety-standards/voluntary-ai-safety-standard-10-guardrails.md
+++ b/docs/safety-standards/voluntary-ai-safety-standard-10-guardrails.md
@@ -29,7 +29,7 @@ Importantly, the 10 guardrails are consistent with leading international standar
 - [**ISO/IEC 42001:2023** – AI Management System Standard](https://www.iso.org/standard/81230.html)  
 - [**NIST AI Risk Management Framework 1.0**](https://www.nist.gov/itl/ai-risk-management-framework)  
 
-### Why this matters
+## Why this matters
 Adopting the guardrails early helps organisations build **trust, resilience, and regulatory readiness**. By embedding these practices now, businesses can:  
 
 - Reduce risks from bias, errors, and misuse of AI  

--- a/scripts/validate_headings.py
+++ b/scripts/validate_headings.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Validate Markdown heading hierarchy.
+
+This script ensures that each Markdown file under ``docs/`` contains
+exactly one level-1 heading (``#``) and that it appears before any lower
+level headings. Front matter blocks and fenced code blocks are ignored
+when scanning for headings.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+HEADING_PATTERN = re.compile(r"^(#{1,6})\s+.+$")
+
+
+@dataclass
+class HeadingIssue:
+    path: Path
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - trivial formatting helper
+        return f"{self.path}: {self.message}"
+
+
+def iter_markdown_files(root: Path) -> Iterable[Path]:
+    for path in sorted(root.rglob("*.md")):
+        if path.name.startswith('.'):
+            continue
+        yield path
+
+
+def scan_file(path: Path) -> List[HeadingIssue]:
+    issues: List[HeadingIssue] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    idx = 0
+    if lines and lines[0].strip() == "---":
+        idx = 1
+        while idx < len(lines) and lines[idx].strip() != "---":
+            idx += 1
+        if idx >= len(lines):
+            issues.append(HeadingIssue(path, "Front matter not terminated"))
+            return issues
+        idx += 1  # skip closing --- line
+
+    in_code_fence = False
+    first_heading_level: int | None = None
+    previous_heading_level: int | None = None
+    h1_count = 0
+
+    for line in lines[idx:]:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_fence = not in_code_fence
+            continue
+        if in_code_fence or not stripped:
+            continue
+
+        match = HEADING_PATTERN.match(line)
+        if not match:
+            continue
+
+        level = len(match.group(1))
+        if first_heading_level is None:
+            first_heading_level = level
+            if level != 1:
+                issues.append(HeadingIssue(path, "First heading is not level 1"))
+        if level == 1:
+            h1_count += 1
+        if previous_heading_level is not None and level - previous_heading_level > 1:
+            issues.append(
+                HeadingIssue(
+                    path,
+                    f"Heading level jumps from H{previous_heading_level} to H{level}",
+                )
+            )
+        previous_heading_level = level
+
+    if h1_count == 0:
+        issues.append(HeadingIssue(path, "No level-1 heading found"))
+    elif h1_count > 1:
+        issues.append(HeadingIssue(path, f"Multiple level-1 headings found ({h1_count})"))
+
+    return issues
+
+
+def main() -> int:
+    docs_root = Path("docs")
+    if not docs_root.exists():
+        print("docs/ directory not found", file=sys.stderr)
+        return 2
+
+    issues: List[HeadingIssue] = []
+    for path in iter_markdown_files(docs_root):
+        issues.extend(scan_file(path))
+
+    if issues:
+        for issue in issues:
+            print(issue, file=sys.stderr)
+        return 1
+
+    print("All Markdown headings are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a reusable script to validate the Markdown heading hierarchy and enforce a single H1 per page
- fix inconsistent heading levels across the AI learning directory and AI safety standards pages

## Testing
- python scripts/validate_headings.py
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68f578809b1483258a774f8ab30e7705