### PR TITLE
Update North American AI timelines and expand Australian guardrails guidance

### DIFF
--- a/docs/safety-standards/ai-australian-legislation.md
+++ b/docs/safety-standards/ai-australian-legislation.md
@@ -20,7 +20,7 @@ canonical_url: "https://safeaiaus.org/safety-standards/ai-australian-legislation
 
 While Australia doesn’t yet have AI-specific legislation, AI use is already governed by existing laws. Australian law is technology-neutral: obligations around privacy, consumer protection, discrimination, and intellectual property apply regardless of whether a decision is made by a human or an AI system.  
 
-As of August 2025, the Government is also considering new AI-specific regulation, including mandatory guardrails for high-risk applications, but outcomes remain politically uncertain.  
+In September 2024, the Government released proposals for mandatory guardrails for high-risk AI applications and introduced a Voluntary AI Safety Standard. Public consultation closed in October 2024, and the Government is now reviewing feedback. Implementation of mandatory requirements is not expected until 2026 at the earliest, though outcomes remain politically uncertain.
 
 ## Why this matters
 Understanding the current legal landscape helps organisations:  
@@ -28,7 +28,8 @@ Understanding the current legal landscape helps organisations:
 - Avoid legal and reputational risks from misuse of AI  
 - Demonstrate compliance and accountability to regulators and customers  
 - Build trust by applying the same standards to AI as to human decision-making  
-- Prepare for upcoming AI-specific laws and reforms in Australia  
+- Prepare for upcoming AI-specific laws and reforms in Australia
+- Adopt the Voluntary AI Safety Standard now to demonstrate best practice and readiness for mandatory guardrails
 
 ---
 
@@ -127,10 +128,27 @@ Australia’s **IP laws**—covering copyright, patents, trademarks, and design 
 ---
 
 ## Emerging Reforms (2025-2026 to watch)
-- **Privacy Act reforms** – stronger consent rules, right to explanation of AI-driven decisions, direct rights of action, and higher penalties  
-- **Mandatory AI guardrails** – under consultation, could apply in high-risk applications (healthcare, employment, finance, infrastructure)  
-- **Potential AI-specific legislation** – Government has signalled a possible AI Act (similar to EU), with algorithm auditing and liability frameworks  
-- **Copyright reforms** – clarifying use of training data, exceptions for text/data mining, rules on AI-generated content  
+- **Voluntary AI Safety Standard (September 2024)** – now in effect, providing 10 voluntary guardrails for responsible AI development and deployment across all sectors. Organizations can adopt these standards immediately to demonstrate best practice and prepare for future mandatory requirements.
+- **Mandatory AI guardrails** – proposed in September 2024 for high-risk applications (healthcare, employment, finance, infrastructure, education, housing, insurance, legal services). Public consultation closed October 2024; Government is reviewing feedback. The 10 proposed mandatory guardrails align closely with the voluntary standard and focus on accountability, risk management, data protection, testing, human oversight, transparency, and incident response. Implementation expected 2026 at earliest.
+- **Regulatory approach** – Government considering three options: (1) domain-specific approach integrating guardrails into existing laws sector-by-sector; (2) framework legislation creating overarching AI requirements; or (3) whole-of-economy AI Act similar to the EU model with dedicated regulator.
+- **Privacy Act reforms** – stronger consent rules, right to explanation of AI-driven decisions, direct rights of action, and higher penalties remain under consideration.
+- **Copyright reforms** – clarifying use of training data, exceptions for text/data mining, rules on AI-generated content.
+
+## Voluntary AI Safety Standard (In Effect Now)
+The Australian Government released the Voluntary AI Safety Standard in September 2024 as an interim measure while mandatory regulations are developed. The Standard consists of 10 voluntary guardrails that align with international best practices and the proposed mandatory guardrails:
+
+1. **Accountability** – establish governance processes and strategies for regulatory compliance
+2. **Risk management** – identify and mitigate AI-related risks throughout the lifecycle
+3. **Data protection** – implement data governance for quality, security and provenance
+4. **Testing and monitoring** – test AI before deployment and monitor ongoing performance
+5. **Human oversight** – enable meaningful human control and intervention
+6. **Transparency** – provide clear information about AI capabilities, limitations and use
+7. **Fairness** – address bias and ensure equitable outcomes
+8. **Privacy protection** – safeguard personal information in AI systems
+9. **Incident response** – establish processes to identify and respond to AI failures or harms
+10. **Stakeholder engagement** – consult with affected communities and gather feedback
+
+Organizations developing or deploying AI systems should consider adopting these voluntary standards now to demonstrate responsible AI practices and prepare for future mandatory compliance obligations.
 
 ---
 
@@ -146,6 +164,7 @@ Australia’s **IP laws**—covering copyright, patents, trademarks, and design 
 | **APRA**                        | AI in risk management and critical infrastructure                            | Meet prudential standards for AI oversight                                       |
 | **TGA**                         | AI in medical devices                                                        | Register & test AI systems, comply with TGA rules                                |
 | **Fair Work Commission**        | Algorithmic HR and recruitment                                               | Ensure compliance with employment and anti-discrimination laws                   |
+| **Voluntary AI Safety Standard** | 10 voluntary guardrails for all AI systems                                   | Adopt voluntary guardrails now; prepare for mandatory requirements expected 2026+ |
 
 ---
 
@@ -154,13 +173,16 @@ Even before new AI laws are introduced, **existing legislation creates clear com
 
 - Treat AI as subject to the same laws as human decision-making  
 - Document AI-related policies and processes  
-- Engage legal review for higher-risk applications  
+- Engage legal review for higher-risk applications
+- Consider implementing the Voluntary AI Safety Standard (September 2024) to align with emerging best practices and prepare for mandatory guardrails expected in 2026
 
 ---
 
 ### Key References
-- [OAIC – Privacy Act & AI Guidance](https://www.oaic.gov.au)  
-- [ACCC – AI and Consumer Law](https://www.accc.gov.au)  
-- [Australian Human Rights Commission – Anti-Discrimination Guidance](https://humanrights.gov.au)  
-- [IP Australia – Intellectual Property and AI](https://www.ipaustralia.gov.au)  
-- [Australian Government – Privacy Act Reforms 2024](https://www.ag.gov.au)  
+- [OAIC – Privacy Act & AI Guidance](https://www.oaic.gov.au)
+- [ACCC – AI and Consumer Law](https://www.accc.gov.au)
+- [Australian Human Rights Commission – Anti-Discrimination Guidance](https://humanrights.gov.au)
+- [IP Australia – Intellectual Property and AI](https://www.ipaustralia.gov.au)
+- [Australian Government – Privacy Act Reforms 2024](https://www.ag.gov.au)
+- Voluntary AI Safety Standard (September 2024): [Department of Industry, Science and Resources](https://www.industry.gov.au/publications/voluntary-ai-safety-standard)
+- Proposals Paper: Safe and Responsible AI - Mandatory Guardrails (September 2024): [Department of Industry, Science and Resources](https://consult.industry.gov.au/ai-mandatory-guardrails)

--- a/docs/safety-standards/international-ai-legal-overview.md
+++ b/docs/safety-standards/international-ai-legal-overview.md
@@ -18,7 +18,7 @@ canonical_url: "https://safeai-aus.github.io/safety-standards/international-ai-l
 
 # International AI Legal Landscape (2025) — What Australian Businesses Should Know
 
-*Last updated: 20 August 2025 (AUS/Adelaide). This page is informational and not legal advice.*
+*Last updated: 20 October 2025 (AUS/Adelaide). This page is informational and not legal advice.*
 
 As AI regulation accelerates globally, many jurisdictions already impose binding requirements or have near-term obligations that will affect Australian organisations exporting, operating, or handling data linked to those regions. 
 
@@ -29,7 +29,7 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 ## Executive Snapshot
 
 - **EU** — The **EU AI Act** is in force with staged obligations. Bans on “unacceptable risk” uses started **2 Feb 2025**; **general-purpose AI (GPAI)** duties start **2 Aug 2025**; most remaining rules phase in through **2026–2027**. Expect documentation, transparency, risk management and post-market monitoring obligations if you sell into the EU or provide GPAI there.  
-- **US** — No single federal AI law. Federal direction runs through **NIST AI RMF 1.0** and public-sector guidance (**OMB M-24-10**). States are moving: **Colorado’s AI Act** (effective **1 Feb 2026**) requires risk programs, impact assessments and notices for “high-risk” AI. NYC mandates bias audits for automated hiring tools.  
+- **US** — No single federal AI law. Federal direction runs through **NIST AI RMF 1.0** and public-sector guidance (**OMB M-24-10**). States are moving: **Colorado’s AI Act** (effective **30 June 2026**) requires risk programs, impact assessments and notices for “high-risk” AI. NYC mandates bias audits for automated hiring tools.
 - **Canada** — The federal **Artificial Intelligence and Data Act (AIDA)** (within Bill C-27) has **not been enacted** as of Aug 2025; it may be revisited in a new parliamentary session. Draft guidance remains a good indicator of direction (risk-based duties for “high-impact” systems).  
 - **UK** — No single AI Act; **regulator-led, “pro-innovation”** model with central government coordination and the **UK AI Safety Institute**. Regulators are issuing sector guidance and pilots (assurance, sandboxes).  
 - **Japan** — Operates “**soft-law**” guidance (**AI Guidelines for Business**, 2024; updated thereafter). In **May 2025** Japan approved an **AI Promotion Act** focused on coordination and R&D; compliance is driven via guidelines and existing laws (e.g., privacy, consumer).  
@@ -56,15 +56,15 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 - For **GPAI/models**, prepare **training-data summaries**, technical documentation, and risk-mitigation processes (red-teaming, incident reporting).  
 
 ### United States (US)
-**Status & scope:** No omnibus federal AI law. Federal levers include **NIST AI RMF 1.0** (widely adopted) and **OMB M-24-10** (governance for US federal agencies). States and cities are active: **Colorado SB24-205** (effective **1 Feb 2026**) mandates **risk management programs, impact assessments, consumer notices and appeal/human review** for “high-risk” AI; **NYC Local Law 144** requires **bias audits and notices** for automated hiring tools.  
+**Status & scope:** No omnibus federal AI law. Federal levers include **NIST AI RMF 1.0** (widely adopted) and **OMB M-24-10** (governance for US federal agencies). States and cities are active: **Colorado SB24-205** (effective **30 June 2026**, delayed from the original February 2026 date via SB 25B-004) mandates **risk management programs, impact assessments, consumer notices and appeal/human review** for “high-risk” AI; **NYC Local Law 144** requires **bias audits and notices** for automated hiring tools.
 **What to do:**
 
 - Align your program to **NIST AI RMF** (often accepted as a **defence/interoperability** baseline, including in Colorado’s framework).  
 - If serving US customers/employers, build **impact assessment** and **bias-audit** capability into your lifecycle.  
 
 ### Canada
-**Status & scope:** The federal **AIDA** (within Bill C-27) **did not pass** before the previous session ended; status is **uncertain** as of Aug 2025. Government materials outline a **risk-based** regime for “high-impact” systems if/when re-introduced.  
-**What to do:** Monitor re-introduction; use AIDA’s companion guidance as **design input** for governance (impact assessments, incident reporting) to future-proof.  
+**Status & scope:** Bill C-27 (which included the federal Artificial Intelligence and Data Act, AIDA) died on the Order Paper on 6 January 2025 when Parliament was prorogued. The bill would need to be completely re-introduced in a future parliamentary session. In June 2025, Minister Evan Solomon confirmed AIDA will not return in its original form, signaling a "light, tight, right" approach to any future AI regulation. Status remains highly uncertain as of October 2025.
+**What to do:** No federal AI-specific law is imminent. Continue monitoring for potential re-introduction under a new government. Organizations can still reference AIDA's former companion guidance for voluntary best practices (risk-based duties for "high-impact" systems, impact assessments, incident reporting), but recognize any future legislation may differ substantially.
 
 ### United Kingdom (UK)
 **Status & scope:** **No single AI Act**; the UK follows a **contextual, regulator-led** approach under the **Government Response (Feb 2024)** to its AI White Paper. Central functions coordinate regulators; the **UK AI Safety Institute** evaluates advanced systems and supports guidance/testing.  
@@ -89,8 +89,8 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 | Jurisdiction | Legal posture (Aug 2025) | Primary instruments | Key dates | Headline obligations (examples) |
 |---|---|---|---|---|
 | **EU** | Binding, phased | EU AI Act | Feb 2025 (bans); **Aug 2025 (GPAI)**; 2026–27 (high-risk) | Risk-tiered duties, GPAI transparency/docs, post-market monitoring, penalties up to 7% turnover |
-| **US** | Patchwork + federal guidance | NIST AI RMF; OMB M-24-10; **Colorado AI Act**; NYC AEDT law | **CO:** 1 Feb 2026; **NYC AEDT:** in force | Risk programs, **impact assessments**, notices, bias audits (hiring), consumer appeal/human review |
-| **Canada** | Proposed (not enacted) | **AIDA (Bill C-27)** + companion doc | Status uncertain | Anticipated risk-based regime for “high-impact” systems; monitor for re-intro |
+| **US** | Patchwork + federal guidance | NIST AI RMF; OMB M-24-10; **Colorado AI Act**; NYC AEDT law | **CO:** 30 June 2026; **NYC AEDT:** in force | Risk programs, **impact assessments**, notices, bias audits (hiring), consumer appeal/human review |
+| **Canada** | Dead (died Jan 2025) | **AIDA (Bill C-27)** – terminated | No timeline; re-introduction uncertain | Bill C-27 died on Order Paper; any future legislation may differ substantially from original AIDA proposal |
 | **UK** | Regulator-led framework | Gov’t Response (Feb 2024); AI Safety Institute | Ongoing | Sector regulators issue guidance; evaluation & assurance focus (frontier/GPAI) |
 | **Japan** | Soft-law + promotion act | **AI Guidelines for Business**; **AI Promotion Act (2025)** | Guidelines ongoing; Act passed May 2025 | Lifecycle governance guidance; coordination/R&D focus under Act |
 | **Korea** | Binding (framework) | **AI Basic/Framework Act** | **Effective Jan 2026** | National governance; trust/safety foundations; further rules expected |
@@ -121,7 +121,7 @@ This page should be read together with our governance tools:
 ### Key References
 - **EU AI Act** timelines & GPAI guidance: European Commission / EU AI Office  
 - **US**: NIST AI RMF 1.0; OMB M-24-10; Colorado SB24-205; NYC Local Law 144  
-- **Canada**: LEGISinfo status for Bill C-27; ISED AIDA companion docs  
+- **Canada**: Bill C-27 (terminated 6 Jan 2025); former ISED AIDA companion docs remain as reference materials only
 - **UK**: Government Response (Feb 2024); UK AI Safety Institute  
 - **Japan**: METI/MIC AI Guidelines for Business; Japan AI Promotion Act overview  
 - **South Korea**: MSIT press release; AI Basic Act analysis  


### PR DESCRIPTION
## Summary
- update US Colorado AI Act effective date and reflect Canada AI bill status across the international overview
- refresh the overview metadata and references to note the October 2025 update
- expand the Australian AI legislation page with voluntary standard guidance, reform details, and related references

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_6901976f9cb0832584124034bc32c95b