### PR TITLE
Point favicon links to assets root

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -5,4 +5,18 @@
   {% if config.extra.canonical_base %}
     <meta name="canonical-base" content="{{ config.extra.canonical_base }}">
   {% endif %}
+
+  <!-- Favicons -->
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ base_url }}/assets/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ base_url }}/assets/favicon-16x16.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ base_url }}/assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="48x48" href="{{ base_url }}/assets/favicon-48x48.png">
+  <link rel="icon" type="image/png" sizes="96x96" href="{{ base_url }}/assets/favicon-96x96.png">
+  <link rel="icon" type="image/png" sizes="180x180" href="{{ base_url }}/assets/favicon-180x180.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="{{ base_url }}/assets/android-chrome-192x192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="{{ base_url }}/assets/android-chrome-512x512.png">
+  <link rel="manifest" href="{{ base_url }}/assets/site.webmanifest">
+  <link rel="mask-icon" href="{{ base_url }}/assets/safari-pinned-tab.svg" color="#0b6428">
+  <meta name="msapplication-TileColor" content="#f7f1e6">
+  <meta name="theme-color" content="#ffffff">
 {% endblock %}


### PR DESCRIPTION
## Summary
- update the favicon link tags to reference icons located directly under docs/assets
- remove the previously committed docs/assets/favicons directory so the repo no longer tracks binary icon files

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_690982e49fe88325a9b65011cab9ce7e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds favicon link tags, web manifest, mask-icon, and theme color meta in `overrides/main.html` pointing to assets under `assets/`.
> 
> - **Docs Template (`overrides/main.html`)**:
>   - Add favicon links (`apple-touch-icon`, multiple PNG sizes) referencing `assets/` via `base_url`.
>   - Add PWA-related assets: `site.webmanifest`, `safari-pinned-tab.svg` (mask-icon).
>   - Add meta tags: `msapplication-TileColor` and `theme-color`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a3a2ed9a783a7bf7fa41eb0a94acf4a9c5cfb89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->