### PR TITLE
Allow Cusdis embeds by relaxing CSP and COEP headers

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -7,15 +7,15 @@
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
   
   # Content Security Policy
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is https://cusdis.com https://js.cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://cloud.umami.is https://cusdis.com https://js.cusdis.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is https://cusdis.com https://js.cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://cloud.umami.is https://cusdis.com https://js.cusdis.com; frame-src 'self' https://cusdis.com https://js.cusdis.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
   
   # HSTS (HTTP Strict Transport Security)
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   
   # Additional Security
-  Cross-Origin-Embedder-Policy: require-corp
-  Cross-Origin-Opener-Policy: same-origin
-  Cross-Origin-Resource-Policy: same-origin
+  Cross-Origin-Embedder-Policy: unsafe-none
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
+  Cross-Origin-Resource-Policy: cross-origin
 
 # Cache headers for different asset types
 /assets/*
@@ -23,7 +23,7 @@
   Cache-Control: public, max-age=86400, must-revalidate
   
   # Less restrictive CSP for assets
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is https://cusdis.com https://js.cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://cloud.umami.is https://cusdis.com https://js.cusdis.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is https://cusdis.com https://js.cusdis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://cloud.umami.is https://cusdis.com https://js.cusdis.com; frame-src 'self' https://cusdis.com https://js.cusdis.com; object-src 'none'; base-uri 'self'; form-action 'self'
 
 # Cache CSS files for 24 hours (good balance)
 *.css


### PR DESCRIPTION
## Summary
- allow Cusdis comment iframes by permitting their domains in the frame-src directive
- relax cross-origin isolation headers so third-party services like Cusdis and Umami can load

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_6909e13683c483259aa0a53d7db30583

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Relaxes CSP and cross-origin headers to allow Cusdis iframes and third-party embeds.
> 
> - **Security headers (`docs/_headers`)**:
>   - **CSP**: Allow iframes by changing `frame-src` from `'none'` to `'self' https://cusdis.com https://js.cusdis.com` (also applied under `/assets/*`).
>   - **Cross-origin policies**: Relaxed headers — `Cross-Origin-Embedder-Policy: unsafe-none`, `Cross-Origin-Opener-Policy: same-origin-allow-popups`, `Cross-Origin-Resource-Policy: cross-origin`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04ed8f6e893c4e6ea2069f876989c4c8807de114. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->