### PR TITLE
Add industry-specific AI risk examples

### DIFF
--- a/docs/governance-templates/ai-risks-by-industry.md
+++ b/docs/governance-templates/ai-risks-by-industry.md
@@ -1,0 +1,187 @@
+---
+layout: page
+title: "AI Risks by Industry (Australia)"
+description: "Industry-specific AI risk examples for 14 major Australian sectors, helping organisations enrich their AI risk registers with sector-tailored threats."
+keywords: "AI risk examples, industry-specific AI risks, Australian AI governance, AI risk register support, sector AI risk tables, SME AI risks"
+author: "SafeAI-Aus"
+robots: "index, follow"
+og_title: "AI Risks by Industry (Australia)"
+og_description: "Sector-specific AI risk examples for Australian industries to extend their AI risk registers."
+og_type: "article"
+og_url: "https://safeaiaus.org/governance-templates/ai-risks-by-industry/"
+og_image: "assets/safeaiaus-logo-600px.png"
+twitter_card: "summary_large_image"
+twitter_title: "AI Risks by Industry (Australia)"
+twitter_description: "Use these sector-specific AI risk examples to strengthen your AI governance."
+canonical_url: "https://safeaiaus.org/governance-templates/ai-risks-by-industry/"
+---
+
+# AI Risks by Industry (Australia)
+
+This page provides example AI-related risks tailored to fourteen major Australian industries, with particular emphasis on sectors with significant SME representation.
+
+These examples help businesses identify context-specific risks before adapting them into their own AI risk registers. Each table includes example risks, brief descriptions, and potential impacts. Organisations can extend these tables with columns for control measures, likelihood, residual risk, and ownership to match the main [AI Risk Register Template](ai-risk-register.md).
+
+**Industry Selection:** The industries featured represent a mix of large enterprise sectors (mining, finance, energy) and SME-dominant sectors (retail, hospitality, professional services, construction) to reflect the diverse Australian business landscape. Priority has been given to sectors with active AI adoption and clear regulatory considerations.
+
+---
+
+## 1. Mining
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| M1 | **Automated Decision Errors in Safety Systems** | AI-driven monitoring or predictive maintenance may fail to detect hazards or equipment faults. | Workplace accidents, injury, production downtime, legal exposure. |
+| M2 | **Data Integrity in Remote Operations** | Inaccurate or tampered IoT/sensor data can lead to poor operational decisions. | Production loss, safety incidents, environmental harm, financial losses. |
+| M3 | **Environmental Impact Misrepresentation** | AI-generated reporting may understate emissions or ecological effects. | State environmental regulator penalties, loss of licence, reputational damage. |
+
+---
+
+## 2. Finance
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| F1 | **Algorithmic Bias in Credit Assessment** | Machine learning models produce discriminatory lending or insurance outcomes. | Regulatory breaches (APRA/ASIC), customer complaints, loss of trust, legal action. |
+| F2 | **Model Explainability & Regulatory Scrutiny** | Limited model transparency may breach APRA/ASIC expectations. | Enforcement action, reputational harm, product suspension, increased compliance costs. |
+| F3 | **Automated Fraud Detection Errors** | AI systems over- or under-flag suspicious activity. | Financial loss, customer frustration, compliance failure, regulatory penalties. |
+
+---
+
+## 3. Retail Trade
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| R1 | **Personalisation and Privacy Breaches** | Excessive data use in recommendation engines breaches privacy obligations. | Privacy Act violations, customer attrition, OAIC complaints, data misuse claims. |
+| R2 | **AI-Generated Marketing Misuse** | AI creates inaccurate or deceptive content breaching Australian Consumer Law. | ACCC enforcement, fines, brand damage, customer loss. |
+| R3 | **Inventory Forecasting Model Degradation** | Model drift causes gradual decline in stock prediction accuracy over time. | Financial loss, supply chain disruption, excess inventory or stockouts, waste. |
+
+---
+
+## 4. Professional, Scientific & Technical Services
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| P1 | **Confidential Client Data Exposure** | AI tools used for analysis leak client or project data through inadequate security. | Contract breach, loss of client trust, reputational damage, legal liability. |
+| P2 | **Reliance on Unverified AI Outputs** | Consultants rely on unvalidated model outputs for client advice. | Misleading clients, professional liability exposure, negligence claims. |
+| P3 | **Inadequate Human Oversight of AI Outputs** | Insufficient review of AI-generated deliverables before client delivery. | Breach of professional codes, ethical violations, quality failures, legal risks. |
+
+---
+
+## 5. Healthcare
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| H1 | **Diagnostic Model Errors** | AI systems make incorrect or biased diagnostic suggestions. | Patient harm, litigation, regulatory sanctions, loss of medical registration. |
+| H2 | **Data Privacy under Health Regulations** | Training data or system design breaches My Health Record requirements and Privacy Act. | Legal penalties, loss of accreditation, OAIC enforcement, public backlash. |
+| H3 | **Bias in Clinical Algorithms** | Narrow or unrepresentative datasets produce unequal treatment outcomes across patient groups. | Health inequities, ethical breaches, discrimination claims, loss of patient confidence. |
+
+---
+
+## 6. Construction
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| C1 | **Design or Structural Planning Faults** | AI-assisted drafting introduces undetected structural errors or code violations. | Safety incidents, structural failure, project delays, legal liability, insurance claims. |
+| C2 | **Worker Safety Monitoring Failures** | AI vision tools or sensor systems miss unsafe conditions on construction sites. | Worker injury, state workplace safety regulator penalties, stop-work orders, reputational harm. |
+| C3 | **Procurement or Supply-Chain Manipulation** | Generative AI produces false supplier documentation or credentials. | Procurement fraud, compliance breaches, project delays, cost overruns, legal action. |
+
+---
+
+## 7. Energy (including Renewables)
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| E1 | **Predictive Maintenance Model Failures** | AI misclassifies equipment anomalies leading to breakdowns, outages or safety incidents. | Safety hazards, environmental harm, service disruption, financial losses. |
+| E2 | **Cyber-Physical Security Breaches** | AI-linked control systems in grid or plant operations expose new attack vectors. | Industrial sabotage, critical infrastructure risk, financial loss, national security concerns. |
+| E3 | **Environmental Compliance Gaps** | Automated emissions or incident reporting misses critical data or misrepresents environmental impact. | State environmental regulator enforcement, loss of licence, fines, reputational damage. |
+
+---
+
+## 8. Wholesale Trade
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| W1 | **Supply Chain Forecasting Errors** | Poor prediction accuracy in demand forecasting causes stock imbalances. | Lost revenue, increased holding costs, dissatisfied clients, supply chain disruption. |
+| W2 | **Automated Product Data Errors** | AI systems populate catalogues with inaccurate specifications, pricing or supplier information. | Customer disputes, contract breaches, brand harm, potential ACL violations. |
+| W3 | **Third-Party AI Dependency** | Heavy reliance on vendor optimisation or procurement tools reduces operational control. | Service disruption, data loss, vendor lock-in, compliance gaps. |
+
+---
+
+## 9. Agriculture
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| A1 | **Sensor and Drone Data Reliability** | Faulty AI analysis of crop, soil or livestock data drives incorrect farming decisions. | Reduced yields, wasted resources, animal welfare issues, financial loss. |
+| A2 | **Algorithmic Over-Application of Resources** | AI irrigation, fertiliser or chemical application models recommend excessive use. | Environmental breaches, increased costs, state environmental regulator penalties, sustainability failures. |
+| A3 | **Biosecurity Data Misclassification** | Models miss or misreport pest, disease or weed patterns critical to biosecurity. | Crop loss, livestock disease, export restrictions, biosecurity incident response failures. |
+
+---
+
+## 10. Manufacturing
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| MN1 | **Quality Control Model Drift** | Changing materials, processes or sensors reduce AI fault detection accuracy over time. | Quality failures, product recalls, safety risks, warranty claims, brand damage. |
+| MN2 | **Intellectual Property Leakage** | Design or process data used in external AI models or cloud services exposes proprietary information. | Competitive disadvantage, IP infringement risk, legal action, loss of trade secrets. |
+| MN3 | **Human-Robot Interaction Failures** | AI-controlled machinery acts unpredictably due to inadequate safeguards or oversight. | Workplace injury, production halt, state workplace safety regulator penalties, liability exposure. |
+
+---
+
+## 11. Hospitality & Tourism
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| HT1 | **Dynamic Pricing Discrimination** | AI pricing algorithms produce outcomes that unfairly discriminate based on protected attributes. | Discrimination complaints, reputational damage, regulatory investigation, loss of customers. |
+| HT2 | **AI Chatbot Misinformation** | Customer service chatbots provide incorrect booking details, pricing or policy information. | Customer complaints, booking errors, ACL breaches, refund costs, reputational harm. |
+| HT3 | **Guest Data Privacy Breaches** | AI systems processing customer preferences or behaviour data breach privacy obligations. | Privacy Act violations, OAIC complaints, loss of customer trust, data breach notification costs. |
+
+---
+
+## 12. Education & Training
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| ED1 | **AI Assessment Bias or Errors** | Automated marking or plagiarism detection produces unfair or inaccurate student outcomes. | Student complaints, academic appeals, discrimination claims, accreditation risk. |
+| ED2 | **Academic Integrity Erosion** | Inadequate detection or policy around AI-generated student work undermines learning outcomes. | Qualification credibility loss, employer complaints, ASQA/TEQSA concerns, reputational damage. |
+| ED3 | **Student Data Privacy Failures** | AI learning platforms or analytics breach student privacy requirements. | Privacy Act violations, regulatory sanctions, loss of enrolments, parental concerns. |
+
+---
+
+## 13. Transport & Logistics
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| TL1 | **Route Optimization Safety Failures** | AI routing algorithms prioritize efficiency over safety considerations or compliance. | Vehicle accidents, driver fatigue, Chain of Responsibility breaches, insurance claims. |
+| TL2 | **Predictive Maintenance Errors** | Incorrect AI predictions about vehicle or equipment maintenance needs. | Vehicle breakdowns, service disruption, safety incidents, increased repair costs. |
+| TL3 | **Driver Monitoring Privacy Issues** | AI systems monitoring driver behaviour breach privacy or workplace surveillance obligations. | Privacy complaints, employee relations issues, Fair Work concerns, trust erosion. |
+
+---
+
+## 14. Real Estate & Property Services
+
+| **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
+|--------------|----------------|-----------------|----------------------|
+| RE1 | **Property Valuation Model Bias** | AI valuation tools produce systematically inaccurate estimates for certain property types or locations. | Financial losses, lending errors, client disputes, professional liability claims. |
+| RE2 | **Discriminatory Property Matching** | AI recommendation engines produce discriminatory outcomes in tenant or buyer matching. | Discrimination complaints, Fair Trading breaches, reputational damage, legal action. |
+| RE3 | **AI-Generated Marketing Misrepresentation** | Automated property descriptions or virtual staging contain false or misleading information. | ACL violations, consumer complaints, regulatory enforcement, loss of licence risk. |
+
+---
+
+## Using These Risk Examples
+
+**For SMEs:**
+- Start with 3-5 risks most relevant to your current or planned AI use
+- Adapt the descriptions to your specific systems and context
+- Add your own control measures and assign ownership
+- Review quarterly as your AI use evolves
+
+**For Larger Organisations:**
+- Use these as a starting point for comprehensive risk registers
+- Expand with additional columns (likelihood, controls, residual risk, review dates)
+- Integrate with existing enterprise risk management frameworks
+- Consider cross-referencing with the [Australian Voluntary AI Safety Standard](../safety-standards/voluntary-ai-safety-standard-10-guardrails.md)
+
+**Important Note:** These examples represent common risk patterns but are not exhaustive. Every organisation should conduct its own risk assessment considering its specific AI applications, data, stakeholders and regulatory environment.
+
+---
+
+*This content is for general guidance only and does not constitute legal or professional advice. Organisations should seek appropriate professional advice for their specific circumstances.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
       - AI Incident Report Form: governance-templates/ai-incident-report-form.md
       - AI Risk Assessment Checklist: governance-templates/ai-risk-assessment-checklist.md
       - AI Risk Register: governance-templates/ai-risk-register.md
+      - AI Risks by Industry (Australia): governance-templates/ai-risks-by-industry.md
       - AI Vendor Evaluation Checklist: governance-templates/ai-vendor-evaluation-checklist.md
       - AI Project Register: governance-templates/ai-project-register.md
   - Practical Business Resources:


### PR DESCRIPTION
## Summary
- add a new governance template page outlining sector-specific AI risk examples for 14 Australian industries with appropriate front matter and internal links
- update the site navigation to surface the new page under the Governance Templates section

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691915dcfbd08325aa3ce124eefa18ba)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new governance template with AI risk examples for 14 Australian industries and updates site navigation to include it.
> 
> - **Documentation**:
>   - **New page**: `docs/governance-templates/ai-risks-by-industry.md` providing sector-specific AI risk tables across 14 industries, with usage guidance, internal cross-links, and SEO/front-matter metadata.
> - **Site Navigation**:
>   - **mkdocs**: Adds `AI Risks by Industry (Australia)` to `Governance Templates` in `mkdocs.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90c6eec048782cb1fbb09b0cd91f21fa7663a1e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->