### PR TITLE
Add agent guidance for repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,150 @@
+# AGENTS.md
+
+This file is for AI coding and documentation agents working on this repository. Humans looking for usage instructions should start with `README.md`.
+
+---
+
+## 1. Project overview
+
+- This repository powers the **SafeAI-Aus** static documentation site built with **MkDocs Material** and deployed via GitHub Pages.
+- Content lives primarily in `docs/`, with the MkDocs configuration in `mkdocs.yml` and custom theme overrides in `overrides/`.
+- The focus is **practical AI safety, governance, and risk management for Australian organisations**.
+- Prefer small, incremental changes that keep the site easy for humans to maintain.
+
+---
+
+## 2. Dev environment & setup
+
+- Requires Python **3.10+**.
+- Dependencies are pinned in `requirements.txt`. To refresh them, use `scripts/update-requirements.sh` rather than editing pins manually.
+
+### Setup commands
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+- If MkDocs plugins complain about version constraints, check `requirements.txt` before updating anything.
+
+---
+
+## 3. Run, build, and check
+
+### Local preview
+
+Use this before changing layout or navigation.
+
+```bash
+mkdocs serve
+```
+
+Default URL: <http://127.0.0.1:8000/>
+
+### Build checks
+
+Build must pass cleanly before merging:
+
+```bash
+mkdocs build --strict
+```
+
+---
+
+## 4. Repository layout
+
+- `mkdocs.yml` — Site configuration, navigation, theme, plugins.
+- `docs/` — All published content (Markdown). Images and assets live under `docs/assets/`.
+- `overrides/` — Theme template and style overrides.
+- `.github/workflows/deploy.yml` — GitHub Actions build and deploy pipeline.
+- `scripts/` — Helper scripts (e.g., dependency updates).
+- `hooks/` — Git hook scripts used by maintainers (avoid changing unless instructed).
+- `AGENTS.md` — This file.
+
+### Navigation rules
+
+- **Source of truth:** `mkdocs.yml` under the `nav:` section.
+- When adding, renaming, or moving docs:
+  - Update `mkdocs.yml` so pages remain reachable.
+  - Check for internal links to the changed page and update them.
+  - Avoid breaking URLs unless necessary; note any changes in the PR description.
+- Keep navigation logical and not overly deep.
+
+---
+
+## 5. Writing & content style (docs/)
+
+- Use **Australian English** (organisation, licence, colour, behaviour).
+- Tone: clear, direct, pragmatic; write for executives and practitioners, not marketing.
+- Short paragraphs; use headings and bullet/numbered lists for clarity.
+- Use tables when comparing options, risks, or frameworks.
+- Cite reputable sources (AU government, standards bodies, regulators). Include name, jurisdiction, year/version, and a stable URL when possible.
+- If unsure about accuracy, either soften the claim or add a TODO for human review.
+
+### Regulatory content requirements
+
+- Flag specific claims about legislation, standards, or government programs with a TODO for human verification.
+- Include the date or version when referencing regulatory documents.
+- Avoid stating compliance requirements as definitive unless quoting official sources.
+- Note when information may be time-sensitive (e.g., funding rounds or consultations).
+
+---
+
+## 6. Safety, legal, and project-specific constraints
+
+- Do **not** change the project licence, legal notices, or attribution statements without explicit instruction.
+- Do **not** introduce tracking, analytics, or third-party scripts beyond what already exists.
+- Avoid adding heavy dependencies that increase maintenance burden without clear justification.
+- Preserve existing disclaimers and risk warnings.
+- Be cautious about claims on future AI capabilities, legal compliance, health, or financial outcomes.
+
+---
+
+## 7. Code & config changes
+
+### MkDocs configuration (`mkdocs.yml`)
+
+- Maintain existing plugins and theme settings unless clearly unused or broken.
+- Keep indentation at 2 spaces.
+- When adding navigation entries, ensure the target paths under `docs/` exist and titles are meaningful.
+
+### CI / workflows (`.github/workflows/`)
+
+- Avoid changing workflow triggers or deployment targets without explicit instruction.
+- If modifying workflows, ensure `mkdocs build --strict` succeeds locally.
+
+---
+
+## 8. Working with content
+
+1. Identify target files in `docs/` based on the requested topic.
+2. Check dependencies: internal links, referenced sections, and nav entries.
+3. Minimise changes; prefer edits over rewrites unless requested.
+4. Preserve headings/anchors that might be linked elsewhere.
+5. Apply the style rules above.
+6. Verify or flag regulatory content with TODOs.
+7. Run `mkdocs build --strict` after changes.
+8. Summarise updates in the PR description or commit message.
+
+---
+
+## 9. Commit / PR conventions
+
+- Commit messages: short, imperative summaries (e.g., `Update AI grants page for 2025`).
+- In PR descriptions, note:
+  - What changed and why.
+  - Any new pages or structural changes.
+  - Any breaking URL changes or redirects.
+  - Any assumptions or TODOs left for human review.
+
+---
+
+## 10. Things to avoid
+
+- Large-scale nav or hierarchy overhauls in a single change.
+- Speculative content without references.
+- SEO-driven wording that reduces clarity.
+- Adding experimental tools, scripts, or binaries.
+
+If a request conflicts with these guidelines, call it out so a human maintainer can decide.


### PR DESCRIPTION
## Summary
- add an AGENTS.md file to guide AI agents working on the documentation site
- outline environment setup, build checks, content style, and contribution conventions tailored to this repo

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bf413557083259b542a834f4c855d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `AGENTS.md` detailing environment setup, build checks, content style, repo conventions, and constraints for AI agents.
> 
> - **Documentation**:
>   - **Add `AGENTS.md`** with guidance for AI agents, covering:
>     - Project overview and repository layout (`mkdocs.yml`, `docs/`, `overrides/`, workflows).
>     - Dev setup (Python 3.10+, `requirements.txt`, virtualenv) and build/preview commands (`mkdocs serve`, `mkdocs build --strict`).
>     - Navigation rules and link management.
>     - Writing style (Australian English), citation practices, and regulatory content requirements.
>     - Safety/legal constraints and dependency/analytics restrictions.
>     - Code/config change guidelines (MkDocs config, CI/workflows).
>     - Content workflow steps and verification checks.
>     - Commit/PR conventions and things to avoid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 218473ef337952df03f2f12b0d08cc8d3f117ba6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->