### PR TITLE
Update R&D tax incentive link

### DIFF
--- a/docs/business-resources/ai-grants-funding-australia.md
+++ b/docs/business-resources/ai-grants-funding-australia.md
@@ -42,12 +42,12 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 - Program **concluded**.  
 - ➡️ [Program details](https://business.gov.au/grants-and-programs/catalysing-the-artificial-intelligence-opportunity-in-our-regions-round-1?)
 
-### R&D Tax Incentive  
-- Ongoing tax relief for businesses conducting R&D, including AI:  
-  - **43.5% refundable offset** for SMEs (<$20m turnover).  
-  - **38.5% non‑refundable offset** for larger firms.  
-- Program is **active and ongoing**.  
-- ➡️ [More information](https://en.wikipedia.org/wiki/Research_and_Development_Tax_Incentive)
+### R&D Tax Incentive
+- Provides **tax offsets to encourage companies to conduct eligible R&D activities that might not otherwise happen**.
+  - **43.5% refundable offset** for R&D entities with aggregated turnover under $20m (not controlled by exempt entities).
+  - **Non‑refundable R&D intensity‑based offset** for larger companies (company tax rate plus a premium tied to R&D intensity).
+- Program is **active and ongoing**; the business.gov.au page does not state a last updated date.
+- ➡️ [Program overview](https://business.gov.au/grants-and-programs/research-and-development-tax-incentive)
 
 ### Australian Research Council (ARC) Programs  
 - Competitive grants supporting research between universities and businesses.  


### PR DESCRIPTION
## Summary
- Replace the R&D Tax Incentive reference with the official business.gov.au program page and reword description to match
- Note that the government source does not provide a last updated date while keeping program status and offset details current

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fcb68d2208325887ba0033b0dbb46)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the R&D Tax Incentive section to use the official business.gov.au source and clarifies offsets and program notes.
> 
> - **Docs** (`docs/business-resources/ai-grants-funding-australia.md`):
>   - **R&D Tax Incentive**: Replace Wikipedia link with official `business.gov.au` program page.
>   - Refresh description and details: `43.5%` refundable for < $20m turnover; intensity-based non‑refundable offset for larger companies.
>   - Add note on program status and absence of a last updated date on the source page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b954021085b5fd00611ae38d0fb82ab1d48fe70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->