### PR TITLE
Update SA AI initiative citation

### DIFF
--- a/docs/business-resources/ai-grants-funding-australia.md
+++ b/docs/business-resources/ai-grants-funding-australia.md
@@ -88,12 +88,12 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 
 ## State-Level Opportunities
 
-### South Australia: $28 Million AI Initiative (2025-2029)  
-- **$7 million annually** for proof‑of‑value trials.  
-- Focused on **healthcare, policing, allied health, social work, and legal/financial services**.  
-- Supports public sector AI adoption while safeguarding jobs.  
-- Program is **active** (2025-2029).  
-- ➡️ [Read more](https://www.news.com.au/technology/innovation/south-australian-treasurer-stephen-mullighan-announces-new-28m-ai-program-in-state-budget/news-story/97fe39eeff3224d0eb3857c7169ce8c2)
+### South Australia: $28 Million AI Initiative (2025-2029)
+- **$7 million annually** for proof‑of‑value trials.
+- Focused on **healthcare, policing, allied health, social work, and legal/financial services**.
+- Supports public sector AI adoption while safeguarding jobs.
+- Program is **active** with funding profiled **from 2025–26 to 2028–29**, as set out in the **2024–25 South Australian State Budget** (Budget Paper 4: Agency Statements – Department of the Premier and Cabinet, released 6 May 2024).
+- ➡️ [Budget Paper 4: Agency Statements (2024–25 SA State Budget)](https://www.treasury.sa.gov.au/statebudget/2024-25/budget-papers)
 
 ### AIML (Australian Institute for Machine Learning) Programs  
 - **Centre for Augmented Reasoning**: $20m federal funding.  


### PR DESCRIPTION
## Summary
- replace the South Australia AI initiative reference with the 2024–25 state budget paper link
- note the 2025–26 to 2028–29 funding profile and include the budget release timing for context

## Testing
- mkdocs build --strict

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fcb6eeae88325a265df1b48f1c8cd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the SA AI initiative news article with an official 2024–25 SA Budget Paper link and clarifies the 2025–26 to 2028–29 funding profile in the State-Level Opportunities section.
> 
> - **Docs** (`docs/business-resources/ai-grants-funding-australia.md`):
>   - **South Australia: $28m AI Initiative**:
>     - Replace news article citation with official 2024–25 SA State Budget Paper (Budget Paper 4) link.
>     - Clarify funding profile: 2025–26 to 2028–29; note budget release context.
>     - Minor formatting clean-up of bullet list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ed18e00d1ffa8c3df2c2eb99c2ccb50d4e6396f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->