### PR TITLE
Update links to use new AI Risks by Industry file

### DIFF
--- a/docs/governance-templates/ai-risk-assessment-checklist.md
+++ b/docs/governance-templates/ai-risk-assessment-checklist.md
@@ -186,6 +186,9 @@ Additional considerations for risk level:
 ---
 ## Next Steps
 **Need to track and monitor risks over time?** → [AI Risk Register](ai-risk-register.md)
+
+**Looking for industry-specific risk examples?** → [AI Industry-Specific Risks](ai-risks-by-industry.md)
+
 **Need to prepare for AI incidents?** → [AI Incident Report Form](ai-incident-report-form.md)
 
 ---

--- a/docs/governance-templates/ai-risk-register.md
+++ b/docs/governance-templates/ai-risk-register.md
@@ -86,9 +86,12 @@ The risk register process is not just a compliance exercise — it is a practica
 ## Next Steps
 **Ready to assess specific AI risks?** → [AI Risk Assessment Checklist](ai-risk-assessment-checklist.md)
 
+**Looking for industry-specific risks?** → [AI Industry-Specific Risks](ai-risks-by-industry.md)
+
 ### Related Governance Templates
 - [AI Project Register](ai-project-register.md) — keep oversight of the AI initiatives that feed into this risk register.
 - [AI Vendor Evaluation Checklist](ai-vendor-evaluation-checklist.md) — evaluate third-party tools before adding them to the register.
+- [AI Industry-Specific Risks](ai-risks-by-industry.md) — explore context-specific risks by industry to help populate this register.
 
 ---
 

--- a/docs/governance-templates/policy-template-library.md
+++ b/docs/governance-templates/policy-template-library.md
@@ -59,6 +59,9 @@ Together, they support compliance with the **Voluntary AI Safety Standard (10 Gu
 - [AI Risk Register](ai-risk-register.md)  
   *Comprehensive register for identifying, assessing, and managing AI-related risks. Supports Guardrails 3 (Risk Assessment) and integrates with broader GRC processes.*  
 
+- [AI Industry-Specific Risks](ai-risks-by-industry.md)  
+  *Provides context-specific AI risk examples for ten major Australian industries to help organizations identify relevant risks for their risk register.*  
+
 ---
 
 ## Coming Soon
@@ -79,7 +82,7 @@ Together, they support compliance with the **Voluntary AI Safety Standard (10 Gu
 |-----------|------------|-----------------------|
 | 1. Transparency | Clear information on AI use | AI Use Policy |
 | 2. Accountability | Assigning responsibility | AI Use Policy, Human Oversight Plan *(coming soon)* |
-| 3. Risk Assessment | Evaluating risks before use | AI Risk Assessment Form, AI Risk Register |
+| 3. Risk Assessment | Evaluating risks before use | AI Risk Assessment Form, AI Risk Register, AI Industry-Specific Risks |
 | 4. Data Governance | Data quality, bias, provenance | Data Management & Quality Checklist *(coming soon)* |
 | 5. Incident Response | Detecting and reporting issues | AI Incident Report Form |
 | 6. Security | Cyber and system safeguards | AI Risk Assessment Form |
@@ -107,7 +110,7 @@ Together, they support compliance with the **Voluntary AI Safety Standard (10 Gu
       "name": "What AI governance templates are available from SafeAI Aus?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "We provide practical, Australia-focused templates including an AI Use Policy, AI Risk Assessment, AI Risk Register, AI Incident Report, AI Vendor Evaluation, AI Project Register, and related checklists to help Australian businesses start safely and quickly."
+        "text": "We provide practical, Australia-focused templates including an AI Use Policy, AI Risk Assessment, AI Risk Register, AI Industry-Specific Risks, AI Incident Report, AI Vendor Evaluation, AI Project Register, and related checklists to help Australian businesses start safely and quickly."
       }
     },
     {


### PR DESCRIPTION
Update links to use new AI Risks by Industry file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cross-links to the new `AI Industry-Specific Risks` page across templates, and updates guardrail mapping and FAQ text accordingly.
> 
> - **Docs/Templates**
>   - `ai-risk-assessment-checklist.md`
>     - Add "AI Industry-Specific Risks" link in Next Steps.
>   - `ai-risk-register.md`
>     - Add "AI Industry-Specific Risks" link in Next Steps and Related Templates.
>   - `policy-template-library.md`
>     - Add "AI Industry-Specific Risks" to Current Templates list.
>     - Update Guardrail 3 mapping to include `AI Industry-Specific Risks`.
>     - Update FAQ JSON-LD answer to include `AI Industry-Specific Risks`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fb6df1d462f0f9ef11defa385b84659dce870ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->