### PR TITLE
Serve favicon from site root

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -8,6 +8,7 @@
 
   <!-- Favicons -->
   <link rel="apple-touch-icon" sizes="180x180" href="{{ base_url }}/assets/apple-touch-icon.png">
+  <link rel="icon" href="{{ base_url }}/favicon.ico">
   <link rel="icon" type="image/png" sizes="16x16" href="{{ base_url }}/assets/favicon-16x16.png">
   <link rel="icon" type="image/png" sizes="32x32" href="{{ base_url }}/assets/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="64x64" href="{{ base_url }}/assets/favicon-64x64.png">


### PR DESCRIPTION
## Summary
- reference the root-level favicon in the main override so crawlers looking for `/favicon.ico` can find it
- drop the tracked copy of `docs/favicon.ico` so the binary can be added outside this PR

## Testing
- mkdocs build --strict

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692517f616488325bd13b90eda37959c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add root-level favicon link (`<link rel="icon" href="/favicon.ico">`) to `overrides/main.html` so `/favicon.ico` is served and discoverable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 801dd6a13218c6939585bce97f7128938dddc2f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->