### PR TITLE
Add LinkedIn link to social icons

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,8 @@ extra:
       link: https://github.com/safeai-aus/safeai-aus.github.io
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/safeai_aus
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/company/safeai-aus
   generator: false
 
 # Add custom CSS for SEO and UX improvements


### PR DESCRIPTION
## Summary
- add SafeAI-Aus LinkedIn link to the MkDocs social icons list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692532aaa5d88325b66fd1a328e304ae)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds SafeAI-Aus LinkedIn profile to `extra.social` in `mkdocs.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b36451fca5737759e110e69be8fc2a448ee01c3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->