### PR TITLE
Reapply MIT OCW AI course link

### DIFF
--- a/docs/business-resources/ai-learning-development-directory.md
+++ b/docs/business-resources/ai-learning-development-directory.md
@@ -118,10 +118,10 @@ Each resource includes details on **format, eligibility, cost, and difficulty le
 
 ### Global & Open Access Courses
 
-#### 8. [MIT OpenCourseWare – AI & ML Courses](https://ocw.mit.edu)
+#### 8. [MIT OpenCourseWare – AI & ML Courses](https://ocw.mit.edu/search/?d=Course&q=artificial%20intelligence%20machine%20learning)
 *MIT*
 
-- **Description:** Deep-dive curriculum including lectures, notes, and problem sets on foundational AI and ML techniques.  
+- **Description:** Search results listing MIT OCW courses tagged with artificial intelligence and machine learning, including lectures, notes, and problem sets, with filters for course level and department.
 - **Format:** Full university course materials.  
 - **License:** CC BY-NC-SA.  
 - **Cost:** **Free**.  


### PR DESCRIPTION
## Summary
- reapply the MIT OpenCourseWare entry to the AI/ML course search results after source updates
- note available filters for course level and department in the description

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69268dd4aedc8325bf979502954df8f3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update MIT OCW AI/ML entry to use the AI/ML search results URL and revise its description to reflect searchable filters and content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b76ae7c7846c4cada298dddfd6a7a9241205021d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->