### PR TITLE
Refresh AI learning directory metadata

### DIFF
--- a/docs/business-resources/ai-learning-development-directory.md
+++ b/docs/business-resources/ai-learning-development-directory.md
@@ -8,12 +8,12 @@ robots: "index, follow"
 og_title: "AI & Emerging Tech Learning Directory for SMEs"
 og_description: "Discover 11+ free AI learning resources for Australian SMEs. Access government programs, university courses, and open-source training to build AI capability."
 og_type: "article"
-og_url: "https://safeai-aus.github.io/business-resources/ai-learning-development-directory/"
-og_image: "assets/safeaiaus-logo-600px.png"
+og_url: "https://safeaiaus.org/business-resources/ai-learning-development-directory/"
+og_image: "https://safeaiaus.org/assets/safeaiaus-logo-600px.png"
 twitter_card: "summary_large_image"
 twitter_title: "AI & Emerging Tech Learning Directory for SMEs"
 twitter_description: "Discover 11+ free AI learning resources for Australian SMEs. Access government programs, university courses, and open-source training to build AI capability."
-canonical_url: "https://safeai-aus.github.io/business-resources/ai-learning-development-directory/"
+canonical_url: "https://safeaiaus.org/business-resources/ai-learning-development-directory/"
 ---
 
 # AI & Emerging Tech Learning Directory for SMEs
@@ -220,8 +220,8 @@ Under the following terms:
 - **Attribution** — You must give appropriate credit, provide a link to the licence, and indicate if changes were made.  
 - **Exclusions** — This licence does not apply to the SafeAI-Aus name, logo, or any third-party material referenced in this document.  
 
-**Attribution statement for reuse:**  
-“This resource was developed by SafeAI-Aus and is licensed under CC BY 4.0. Source: [SafeAI-Aus](https://safeai-aus.github.io/).”  
+**Attribution statement for reuse:**
+“This resource was developed by SafeAI-Aus and is licensed under CC BY 4.0. Source: [SafeAI-Aus – AI & Emerging Tech Learning Directory for SMEs](https://safeaiaus.org/business-resources/ai-learning-development-directory/).”
 
 Full licence text: [https://creativecommons.org/licenses/by/4.0/](https://creativecommons.org/licenses/by/4.0/)
 

--- a/docs/newsletter/2025_11_26.md
+++ b/docs/newsletter/2025_11_26.md
@@ -1,0 +1,10 @@
+---
+title: "Daily Newsletter Log – 26 Nov 2025"
+description: "SafeAI-Aus change log for 26 November 2025."
+robots: "noindex, follow"
+---
+
+# Content
+
+* Updated AI Learning & Development Directory metadata and attribution links to use the primary safeaiaus.org domain and avoid redirects.
+* Refreshed the directory’s Open Graph image and reuse attribution to point directly to the canonical safeaiaus.org page after upstream content updates.


### PR DESCRIPTION
## Summary
- Point the AI learning directory OG image and reuse attribution to the canonical safeaiaus.org page after upstream content updates
- Record the metadata refresh in the 26 Nov 2025 daily changelog entry

## Testing
- mkdocs build --strict --verbose
- linkchecker --check-extern site/business-resources/ai-learning-development-directory/index.html (errors from proxy blocking external hosts)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69268dcaa340832593c620dc9b437628)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates AI learning directory metadata to canonical safeaiaus.org URLs and logs the change in the Nov 26, 2025 newsletter.
> 
> - **Docs**:
>   - Update Open Graph and canonical metadata in `docs/business-resources/ai-learning-development-directory.md`:
>     - `og_url`, `og_image`, and `canonical_url` now point to `safeaiaus.org`.
>   - Revise reuse attribution statement to link to the canonical directory page on `safeaiaus.org`.
> - **Newsletter**:
>   - Add `docs/newsletter/2025_11_26.md` logging the metadata and attribution updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da62bf95214573989c1025d970597b8133ec292c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->