### PR TITLE
Fix AI change management list formatting

### DIFF
--- a/docs/business-resources/ai-change-management.md
+++ b/docs/business-resources/ai-change-management.md
@@ -53,6 +53,7 @@ AI adoption fails for predictable reasons:
 The result: Low adoption rates, workarounds, and abandoned tools despite significant investment.
 
 **The data is clear:** Organisations that invest in change management see:
+
 - 7x higher likelihood of meeting AI project objectives
 - Faster time to value (months vs years)
 - Higher sustained adoption rates
@@ -119,17 +120,20 @@ This is where good change management separates successful pilots from abandoned 
 ### Communicate regularly
 
 **Weekly check-ins** with pilot participants, not just monthly surveys:
+
 - What's working well?
 - What's frustrating?
 - What questions have come up?
 - What would you change?
 
 **Share progress transparently:**
+
 - "This week, 8 of 12 participants used the tool at least 3 times. We're seeing 25% time savings on document drafting."
 - "We've identified three common errors the AI makes. Here's what we're doing about it."
 - "Several people asked about X – here's the answer."
 
 **Celebrate quick wins openly:**
+
 - Share specific examples where the tool saved time or improved quality
 - Highlight creative uses participants discovered
 - Show how feedback led to changes
@@ -137,12 +141,14 @@ This is where good change management separates successful pilots from abandoned 
 ### Make feedback easy and act on it
 
 **Create low-friction feedback mechanisms:**
+
 - Dedicated Slack channel or Teams chat for quick questions
 - Simple weekly feedback form (3-5 questions, takes 2 minutes)
 - Regular coffee chats (informal, 15-30 minutes)
 - Anonymous option for sensitive concerns
 
 **More importantly, act on feedback visibly:**
+
 - If people raise issues, show what changed as a result
 - If you can't address a concern, explain why and what alternatives you're considering
 - Close the loop: "Last week three people mentioned X – here's what we did about it"
@@ -154,16 +160,19 @@ Nothing kills engagement faster than collecting feedback that disappears into a 
 People learn differently. Provide multiple support options:
 
 **Written guides** for people who prefer self-directed learning:
+
 - Step-by-step instructions with screenshots
 - FAQ document that grows based on real questions
 - Tips and tricks document
 
 **Hands-on practice sessions** for people who learn by doing:
+
 - Weekly "office hours" where people can drop in with questions
 - Pair-up sessions where experienced users help newer ones
 - Real work sessions where a facilitator is present to help
 
 **Peer support and champions:**
+
 - Identify who picks up the tool quickly and ask them to help others
 - Create a "buddy system" pairing confident users with hesitant ones
 - Recognize and thank people who help their peers
@@ -217,12 +226,14 @@ Focus on strategic benefits, risk mitigation, and organisational learning
 **Tool is installed ≠ tool is being used effectively**
 
 Monitor:
+
 - **Usage patterns:** Who's using it? How often? For what tasks?
 - **Quality of outputs:** Are people reviewing AI outputs or blindly accepting them?
 - **Support requests:** What are common issues? Are the same people repeatedly asking for help?
 - **Sentiment:** How do people feel about the tool? (surveys, informal check-ins)
 
 **Be prepared to adjust:**
+
 - If adoption is low, dig into why (training gaps? tool doesn't fit workflow? concerns not addressed?)
 - If quality issues emerge, don't just add more training – examine if the tool is actually suitable
 - If certain teams thrive while others struggle, learn from the differences
@@ -236,6 +247,7 @@ Regional Australian businesses face specific challenges when adopting AI tools. 
 ### Infrastructure realities
 
 **Internet connectivity:**
+
 - Cloud-based AI tools may perform poorly in areas with limited bandwidth
 - Test tools with your actual regional infrastructure before committing
 - Consider hybrid solutions where some processing happens locally
@@ -247,11 +259,13 @@ A regional aged care provider tested an AI documentation tool with their slowest
 ### Remote team coordination
 
 **Challenges:**
+
 - Pilot groups might be geographically distributed
 - In-person training and support is difficult
 - Different teams may have different infrastructure quality
 
 **Approaches that work:**
+
 - Schedule video training sessions that work across time zones
 - Record training sessions for asynchronous access
 - Create strong written documentation since in-person support is harder
@@ -261,11 +275,13 @@ A regional aged care provider tested an AI documentation tool with their slowest
 ### Finding support
 
 **Local expertise may be limited:**
+
 - Regional areas may have fewer AI consultants or technical specialists
 - Remote support and online training may be primary options
 - Consider partnering with city-based providers who offer remote support
 
 **Peer learning can fill gaps:**
+
 - Connect with other regional businesses in your industry
 - Local business chambers or regional development organisations may facilitate connections
 - Online communities and forums can supplement local networks
@@ -273,6 +289,7 @@ A regional aged care provider tested an AI documentation tool with their slowest
 ### Regional advantages
 
 **Don't overlook benefits:**
+
 - Smaller, tighter teams may adopt new tools more cohesively
 - Stronger relationships with suppliers may mean more hands-on support
 - Less complex systems might make pilots simpler to coordinate
@@ -298,22 +315,26 @@ See [AI Implementation Roadmap](ai-implementation-roadmap.md) for practical guid
 ## Key takeaways
 
 **Before pilots:**
+
 - Get buy-in through conversation, not announcement
 - Address concerns proactively with honest, specific answers
 - Set clear expectations about timeline, commitment, and success criteria
 
 **During pilots:**
+
 - Communicate weekly, not monthly
 - Make feedback easy and act on it visibly
 - Support different learning styles
 
 **When scaling:**
+
 - Plan for 2-3x more support than pilots required
 - Tailor messages to different stakeholder groups
 - Track actual adoption, not just deployment
 - Be prepared to adjust based on real usage patterns
 
 **Regional context matters:**
+
 - Test tools with actual infrastructure before committing
 - Build strong documentation for remote support
 - Leverage peer networks when local expertise is limited

--- a/docs/business-resources/ai-implementation-roadmap.md
+++ b/docs/business-resources/ai-implementation-roadmap.md
@@ -60,51 +60,50 @@ Each stage has clear objectives, typical timeframes, and "what done looks like" 
 
 ### What to do
 
-**Identify 2-3 low-risk, high-learning use cases:**
-- Review [Safe AI Adoption - Getting Started](/guides/safe-ai-adoption-getting-started) for good first uses
-- Choose cases that are reversible and low-stakes
-- Pick at least one that builds resilience, not just cuts cost
+- **Identify 2-3 low-risk, high-learning use cases:**
+  - Review [Safe AI Adoption - Getting Started](safe-ai-adoption-getting-started.md) for good first uses
+  - Choose cases that are reversible and low-stakes
+  - Pick at least one that builds resilience, not just cuts cost
 
-**Set up your AI System Register:**
-- Use the [AI System Register Template](/templates/ai-system-register) to track pilots
-- Even a simple spreadsheet is fine at this stage
-- Key fields: use case, owner, risk rating, status, decisions made
+- **Set up your AI System Register:**
+  - Use the [AI Project Register Template](../governance-templates/ai-project-register.md) to track pilots
+  - Even a simple spreadsheet is fine at this stage
+  - Key fields: use case, owner, risk rating, status, decisions made
 
-**Run small pilots with clear parameters:**
+- **Run small pilots with clear parameters:**
+  - **Pilot group size:** 5-15 people
+    - **Why this size:** Large enough to generate meaningful data, small enough to support intensively
+    - **Too small (1-3 people):** Doesn't reveal process or workflow issues
+    - **Too large (30+ people):** Support burden becomes overwhelming, problems scale quickly
 
-**Pilot group size:** 5-15 people
-- **Why this size:** Large enough to generate meaningful data, small enough to support intensively
-- **Too small (1-3 people):** Doesn't reveal process or workflow issues
-- **Too large (30+ people):** Support burden becomes overwhelming, problems scale quickly
+  - **Pilot duration:** 4-8 weeks for initial learning
+    - **Week 1-2:** Setup, training, initial use with high support
+    - **Week 3-5:** Regular use, feedback collection, issue resolution
+    - **Week 6-8:** Evaluation, decision preparation
+    - **Longer pilots (8-12 weeks):** Appropriate for defensive/security use cases or complex workflows
 
-**Pilot duration:** 4-8 weeks for initial learning
-- **Week 1-2:** Setup, training, initial use with high support
-- **Week 3-5:** Regular use, feedback collection, issue resolution
-- **Week 6-8:** Evaluation, decision preparation
-- **Longer pilots (8-12 weeks):** Appropriate for defensive/security use cases or complex workflows
+  - **Success criteria examples:**
+    - "Reduces document drafting time by 20% while maintaining quality"
+    - "Maintains 90% accuracy with human review required for all outputs"
+    - "Staff report tool is helpful, not frustrating, in week 4 survey"
+    - "Zero security incidents during pilot period"
+    - "80% of pilot participants want to continue using the tool"
 
-**Success criteria examples:**
-- "Reduces document drafting time by 20% while maintaining quality"
-- "Maintains 90% accuracy with human review required for all outputs"
-- "Staff report tool is helpful, not frustrating, in week 4 survey"
-- "Zero security incidents during pilot period"
-- "80% of pilot participants want to continue using the tool"
+  - **Exit conditions (when to stop):**
+    - "If error rate exceeds 15% after 4 weeks of tuning"
+    - "If staff satisfaction score below 3/5 after training period"
+    - "If integration issues remain unresolved after 6 weeks"
+    - "If cost per task exceeds current manual process cost"
 
-**Exit conditions (when to stop):**
-- "If error rate exceeds 15% after 4 weeks of tuning"
-- "If staff satisfaction score below 3/5 after training period"
-- "If integration issues remain unresolved after 6 weeks"
-- "If cost per task exceeds current manual process cost"
+- **Complete AI Readiness Checklists:**
+  - Use the [AI Readiness Checklist](../governance-templates/ai-readiness-checklist.md) for each pilot
+  - Document risk assessment, privacy considerations, approval
+  - Lightweight but systematic
 
-**Complete AI Readiness Checklists:**
-- Use the [AI Readiness Checklist](/templates/ai-readiness-checklist) for each pilot
-- Document risk assessment, privacy considerations, approval
-- Lightweight but systematic
-
-**Capture lessons learned:**
-- Weekly pilot review meetings (30 minutes)
-- End-of-pilot retrospective (document what worked, what didn't, what surprised you)
-- Feed insights back into system register and planning
+- **Capture lessons learned:**
+  - Weekly pilot review meetings (30 minutes)
+  - End-of-pilot retrospective (document what worked, what didn't, what surprised you)
+  - Feed insights back into system register and planning
 
 ### What "done" looks like
 
@@ -145,41 +144,41 @@ At the end of Stage 1, you should have:
 
 ### What to do
 
-**Introduce approval and risk checks for new AI projects:**
-- Expand the [AI Readiness Checklist](/templates/ai-readiness-checklist) into standard project approval process
-- New AI initiatives can't start without basic documentation and risk assessment
-- Keep it lightweight – appropriate to risk level, not bureaucratic
+- **Introduce approval and risk checks for new AI projects:**
+  - Expand the [AI Readiness Checklist](../governance-templates/ai-readiness-checklist.md) into standard project approval process
+  - New AI initiatives can't start without basic documentation and risk assessment
+  - Keep it lightweight – appropriate to risk level, not bureaucratic
 
-**Make the system register part of business-as-usual:**
-- Assign an owner for the register (someone senior enough to have authority)
-- Quarterly review of all active AI systems (more frequently for high-risk ones)
-- Clear process for adding new systems and updating status
+- **Make the system register part of business-as-usual:**
+  - Assign an owner for the register (someone senior enough to have authority)
+  - Quarterly review of all active AI systems (more frequently for high-risk ones)
+  - Clear process for adding new systems and updating status
 
-**Establish incident reporting:**
-- Deploy [AI Incident Report Form](/templates/ai-incident-report-form)
-- Make it clear this is learning-focused, not blame-focused
-- Review incidents quarterly to identify patterns and improvement opportunities
-- Feed lessons back into training, documentation, and tool configuration
+- **Establish incident reporting:**
+  - Deploy [AI Incident Report Form](../governance-templates/ai-incident-report-form.md)
+  - Make it clear this is learning-focused, not blame-focused
+  - Review incidents quarterly to identify patterns and improvement opportunities
+  - Feed lessons back into training, documentation, and tool configuration
 
-**Publish AI use guidelines for staff:**
-- Dos and don'ts for common use cases
-- When to use AI vs when not to
-- How to review AI outputs (what to look for)
-- Where to report problems or concerns
-- Keep it to 1-2 pages, practical not theoretical
+- **Publish AI use guidelines for staff:**
+  - Dos and don'ts for common use cases
+  - When to use AI vs when not to
+  - How to review AI outputs (what to look for)
+  - Where to report problems or concerns
+  - Keep it to 1-2 pages, practical not theoretical
 
-**Example guidelines snippet:**
-- ✓ DO use AI for first drafts of routine documents
-- ✓ DO review all AI outputs before using them
-- ✓ DO report errors or concerning outputs
-- ✗ DON'T use AI for decisions about people without human review
-- ✗ DON'T copy-paste AI outputs without checking for accuracy
-- ✗ DON'T put confidential or sensitive data into unapproved AI tools
+- **Example guidelines snippet:**
+  - ✓ DO use AI for first drafts of routine documents
+  - ✓ DO review all AI outputs before using them
+  - ✓ DO report errors or concerning outputs
+  - ✗ DON'T use AI for decisions about people without human review
+  - ✗ DON'T copy-paste AI outputs without checking for accuracy
+  - ✗ DON'T put confidential or sensitive data into unapproved AI tools
 
-**Set up review cadences:**
-- Monthly: Review active pilot metrics and issues
-- Quarterly: Review system register, incident reports, update risk assessments
-- Annually: Review AI use guidelines, governance framework, vendor relationships
+- **Set up review cadences:**
+  - Monthly: Review active pilot metrics and issues
+  - Quarterly: Review system register, incident reports, update risk assessments
+  - Annually: Review AI use guidelines, governance framework, vendor relationships
 
 ### What "done" looks like
 
@@ -207,32 +206,30 @@ At the end of Stage 2, you should have:
 
 ### What to do
 
-**Expand successful pilots to broader teams:**
-- Don't scale everything – focus on what clearly worked
-- Plan for 2-3x more training and support time than pilots required
-- Identify team-level champions (not just organisation-level)
-- Expect slower adoption in scaling phase than pilot phase
+- **Expand successful pilots to broader teams:**
+  - Don't scale everything – focus on what clearly worked
+  - Plan for 2-3x more training and support time than pilots required
+  - Identify team-level champions (not just organisation-level)
+  - Expect slower adoption in scaling phase than pilot phase
 
-**Invest in training and enablement:**
-- Develop self-service resources (written guides, video tutorials, FAQs)
-- Regular training sessions for new users (monthly or as new teams onboard)
-- "Office hours" or drop-in support sessions
-- Update training based on common issues and questions
+- **Invest in training and enablement:**
+  - Develop self-service resources (written guides, video tutorials, FAQs)
+  - Regular training sessions for new users (monthly or as new teams onboard)
+  - "Office hours" or drop-in support sessions
+  - Update training based on common issues and questions
 
-**Prioritise defensive and resilience use cases:**
-- Now that you've learned from productivity use cases, consider defensive ones
-- Security operations support, fraud detection, risk and compliance assistance
-- See [Safe AI Adoption - Getting Started](/guides/safe-ai-adoption-getting-started) for resilience-focused uses
+- **Prioritise defensive and resilience use cases:**
+  - Now that you've learned from productivity use cases, consider defensive ones
+  - Security operations support, fraud detection, risk and compliance assistance
+  - See [Safe AI Adoption - Getting Started](safe-ai-adoption-getting-started.md) for resilience-focused uses
 
-**Track organisation-level metrics:**
-
-Monitor across four dimensions:
-- **Adoption:** How many staff are actively using tools? What percentage of eligible workflows?
-- **Value:** Time saved, quality improvements, cost savings
-- **Risk:** Incident rates and severity, staff confidence in outputs
-- **Support:** Request volumes, common issues, user satisfaction
-
-Track these monthly and look for trends rather than snapshots.
+- **Track organisation-level metrics:**
+  - Monitor across four dimensions:
+    - **Adoption:** How many staff are actively using tools? What percentage of eligible workflows?
+    - **Value:** Time saved, quality improvements, cost savings
+    - **Risk:** Incident rates and severity, staff confidence in outputs
+    - **Support:** Request volumes, common issues, user satisfaction
+  - Track these monthly and look for trends rather than snapshots.
 
 ### What "done" looks like
 
@@ -259,42 +256,41 @@ At the end of Stage 3, you should have:
 
 ### What to do
 
-**Schedule periodic assurance activities:**
+- **Schedule periodic assurance activities:**
+  - **Quarterly reviews for high-risk systems:**
+    - Review incident reports and near misses
+    - Check compliance with risk controls
+    - Verify system performance vs expectations
+    - Update risk assessment if context changes
 
-**Quarterly reviews for high-risk systems:**
-- Review incident reports and near misses
-- Check compliance with risk controls
-- Verify system performance vs expectations
-- Update risk assessment if context changes
+  - **Annual reviews for low-risk systems:**
+    - Confirm system still appropriate for use case
+    - Review vendor relationship and costs
+    - Check for regulatory or technology changes
+    - Update documentation
 
-**Annual reviews for low-risk systems:**
-- Confirm system still appropriate for use case
-- Review vendor relationship and costs
-- Check for regulatory or technology changes
-- Update documentation
+  - **Ad-hoc reviews when triggered:**
+    - Significant incidents or near misses
+    - Major system updates from vendor
+    - Regulatory changes
+    - Workflow or organisational changes
 
-**Ad-hoc reviews when triggered:**
-- Significant incidents or near misses
-- Major system updates from vendor
-- Regulatory changes
-- Workflow or organisational changes
+- **Refine guardrails based on experience:**
+  - What controls are working well? What's pure overhead?
+  - Where are gaps emerging?
+  - What have incidents taught you?
+  - Update guidelines, checklists, and processes accordingly
 
-**Refine guardrails based on experience:**
-- What controls are working well? What's pure overhead?
-- Where are gaps emerging?
-- What have incidents taught you?
-- Update guidelines, checklists, and processes accordingly
+- **Adjust roadmap as context evolves:**
+  - New regulations (track Australian AI legislation development)
+  - New technology capabilities (AI is evolving rapidly)
+  - Changed organisational priorities or risk appetite
+  - Lessons from your experience and others'
 
-**Adjust roadmap as context evolves:**
-- New regulations (track Australian AI legislation development)
-- New technology capabilities (AI is evolving rapidly)
-- Changed organisational priorities or risk appetite
-- Lessons from your experience and others'
-
-**Share lessons learned:**
-- Internally: cross-team learning from experiences
-- Externally: consider contributing to industry knowledge
-- Help others avoid your mistakes, learn from your successes
+- **Share lessons learned:**
+  - Internally: cross-team learning from experiences
+  - Externally: consider contributing to industry knowledge
+  - Help others avoid your mistakes, learn from your successes
 
 ### What "ongoing success" looks like
 
@@ -313,24 +309,24 @@ In the continuous improvement stage, you should have:
 
 ### If you haven't started pilots yet:
 
-1. Review [Safe AI Adoption - Getting Started](/guides/safe-ai-adoption-getting-started) and complete [AI Readiness Checklist](/templates/ai-readiness-checklist)
-2. Set up your [AI System Register](/templates/ai-system-register)
-3. Evaluate 2-3 vendors using [AI Vendor Selection Guide](/guides/ai-vendor-selection)
+1. Review [Safe AI Adoption - Getting Started](safe-ai-adoption-getting-started.md) and complete [AI Readiness Checklist](../governance-templates/ai-readiness-checklist.md)
+2. Set up your [AI System Register](../governance-templates/ai-project-register.md)
+3. Evaluate 2-3 vendors using [AI Vendor Selection Guide](ai-vendor-selection-guide.md)
 4. Design pilot: 5-15 people, 4-8 weeks, clear success criteria and exit conditions
 
 ### If you're running pilots now:
 
 1. Confirm you have clear success criteria, exit conditions, and a decision timeline
 2. Collect feedback weekly and document lessons as you go
-3. Review change management against [AI Change Management](/guides/ai-change-management)
+3. Review change management against [AI Change Management](ai-change-management.md)
 4. Update your system register with pilot status and findings
 
 ### If you're ready to scale:
 
 1. Confirm pilot met success criteria with evidence (don't scale based on enthusiasm alone)
-2. Review guardrails from [Safe AI Adoption - Getting Started](/guides/safe-ai-adoption-getting-started)
+2. Review guardrails from [Safe AI Adoption - Getting Started](safe-ai-adoption-getting-started.md)
 3. Develop training materials and identify team-level champions
-4. Set up [incident reporting](/templates/ai-incident-report-form) and plan for 2-3x more support
+4. Set up [incident reporting](../governance-templates/ai-incident-report-form.md) and plan for 2-3x more support
 
 ---
 
@@ -364,10 +360,10 @@ Perfect is the enemy of good. The goal is deliberate progress with appropriate s
 
 ## Further resources
 
-- [Safe AI Adoption - Getting Started](/guides/safe-ai-adoption-getting-started)
-- [AI Change Management](/guides/ai-change-management)
-- [AI Vendor Selection Guide](/guides/ai-vendor-selection)
-- [AI System Register Template](/templates/ai-system-register)
-- [AI Readiness Checklist](/templates/ai-readiness-checklist)
-- [AI Incident Report Form](/templates/ai-incident-report-form)
-- [AI Assurance – Transparency, Auditing & Reporting](/guides/ai-assurance)
+- [Safe AI Adoption - Getting Started](safe-ai-adoption-getting-started.md)
+- [AI Change Management](ai-change-management.md)
+- [AI Vendor Selection Guide](ai-vendor-selection-guide.md)
+- [AI Project Register Template](../governance-templates/ai-project-register.md)
+- [AI Readiness Checklist](../governance-templates/ai-readiness-checklist.md)
+- [AI Incident Report Form](../governance-templates/ai-incident-report-form.md)
+- [AI Assurance – Transparency, Auditing & Reporting](../governance-templates/ai-assurance-transparency-auditing-reporting.md)

--- a/docs/business-resources/ai-vendor-selection-guide.md
+++ b/docs/business-resources/ai-vendor-selection-guide.md
@@ -55,6 +55,7 @@ Before you evaluate vendors, confirm that buying is the right approach.
 - **Proven in market:** Other organisations have tested and refined the approach
 
 **Typical cost comparison:**
+
 - **Buy:** $200-3,000/month subscription + setup fees ($500-5,000)
 - **Build:** $30,000-100,000+ development + ongoing maintenance costs
 
@@ -87,6 +88,7 @@ Be cautious if a vendor exhibits these warning signs:
 ### 2. Makes unrealistic promises
 
 **Red flags:**
+
 - "100% accuracy"
 - "Fully automated from day one"
 - "No human oversight needed"
@@ -98,6 +100,7 @@ Be cautious if a vendor exhibits these warning signs:
 ### 3. Dismisses your concerns
 
 **Red flags:**
+
 - Brushes off questions about bias with "our AI is unbiased"
 - Treats privacy concerns as paranoia
 - Dismisses error rates as "not a real problem"
@@ -114,6 +117,7 @@ Be cautious if a vendor exhibits these warning signs:
 ### 5. Unclear about data handling
 
 **Red flags:**
+
 - Vague about where data is stored
 - Can't clearly explain who can access your data
 - Unclear how your data is used (training their models? shared with others?)
@@ -124,6 +128,7 @@ Be cautious if a vendor exhibits these warning signs:
 ### 6. Heavy lock-in with no trial period
 
 **Red flags:**
+
 - Requires 12+ month contracts with no trial option
 - High switching costs or data export fees
 - Proprietary data formats that make leaving difficult
@@ -202,22 +207,26 @@ The template covers technical capability, Australian compliance, integration and
 ## Key takeaways
 
 **Build vs buy:**
+
 - Almost always buy for first AI uses
 - Building makes sense only in specific circumstances
 - Pre-built solutions are faster, cheaper, and lower risk
 
 **Red flags to watch for:**
+
 - Can't explain how AI works or makes unrealistic promises
 - No Australian customers or unclear data handling
 - Heavy lock-in or missing security certifications
 
 **Critical questions:**
+
 - Functionality, limitations, and error handling
 - Australian compliance and data sovereignty
 - Integration, support, and transparency
 - Total costs and contract terms
 
 **Use the template:**
+
 - Score vendors consistently
 - Document your evaluation
 - Share assessments across team

--- a/docs/business-resources/safe-ai-adoption-getting-started.md
+++ b/docs/business-resources/safe-ai-adoption-getting-started.md
@@ -87,6 +87,7 @@ These are usually **reversible**, low-stakes, and create quick learning.
 - Suggesting tags, titles or brief descriptions for human approval  
 
 **Typical costs and timeframes:**
+
 - **Pilot phase:** 4-8 weeks, $500-5,000 depending on tool complexity
 - **Scale decision point:** 3-6 months after pilot start
 - **Expected ROI timeframe:** 6-12 months for productivity benefits
@@ -167,6 +168,7 @@ AI can help security and fraud teams by:
 
 ### Operational risk and safety
 
+
 AI can reveal weak signals across:
 
 - Incident and near-miss reports  
@@ -230,6 +232,7 @@ For each new AI use, you should be able to answer:
 These questions link directly to the upcoming AI assurance guidance on transparency, auditing, and reporting.
 
 **Connection to Voluntary AI Safety Standard:** The Australian Government's Voluntary AI Safety Standard emphasises transparency, fairness, and accountability. Your guardrails should demonstrate how you're meeting these principles:
+
 - **Transparency:** Clear documentation in your system register
 - **Fairness:** Risk assessment processes that consider bias and discrimination
 - **Accountability:** Named owners and incident reporting procedures


### PR DESCRIPTION
## Summary
- Add blank lines before bullet lists throughout the AI Change Management page so dot points render correctly

## Testing
- mkdocs build --strict (warnings about missing git logs for draft newsletter pages)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d75b78fc88325adb0b5238c1a5e80)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes markdown list rendering and normalizes internal links across business-resources docs.
> 
> - **Docs (business-resources)**:
>   - **`ai-implementation-roadmap.md`**:
>     - Rewrites list sections into properly nested markdown bullets for readability/rendering.
>     - Normalizes internal links to relative paths and governance templates (e.g., `../governance-templates/...`, local `.md` files).
>     - Updates “Further resources” list accordingly.
>   - **`ai-change-management.md`**:
>     - Adds blank lines before lists to fix bullet rendering.
>   - **`ai-vendor-selection-guide.md` & `safe-ai-adoption-getting-started.md`**:
>     - Adds spacing before lists and minor path fixes for internal links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4f499739b8d36fe14b6c0f42e91a4d10c1ade4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->