### PR TITLE
Fix schema metadata rendering on missing pages

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -19,7 +19,7 @@
   <meta name="msapplication-TileColor" content="#f7f1e6">
   <meta name="theme-color" content="#ffffff">
   <!-- JSON-LD for HowTo Schema -->
-  {% if page.meta.howto %}
+  {% if page and page.meta and page.meta.howto %}
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -40,7 +40,7 @@
   {% endif %}
 
   <!-- JSON-LD for FAQPage Schema -->
-  {% if page.meta.faq %}
+  {% if page and page.meta and page.meta.faq %}
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- guard JSON-LD metadata blocks in the theme override when no page metadata is available (e.g. 404 pages)

## Testing
- mkdocs build --strict

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e80e38ab483259f9855831ed70b17)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add existence checks for `page` and `page.meta` before rendering HowTo and FAQ JSON-LD blocks to avoid errors on pages without metadata.
> 
> - **Theme override** (`overrides/main.html`):
>   - Guard JSON-LD blocks with `page` and `page.meta` checks:
>     - HowTo: `if page and page.meta and page.meta.howto`
>     - FAQ: `if page and page.meta and page.meta.faq`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79fafd2de58b423b895dc829e50876853351eba5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->