### PR TITLE
Fix Australian spelling

### DIFF
--- a/docs/business-resources/ai-change-management.md
+++ b/docs/business-resources/ai-change-management.md
@@ -174,7 +174,7 @@ People learn differently. Provide multiple support options:
 
 - Identify who picks up the tool quickly and ask them to help others
 - Create a "buddy system" pairing confident users with hesitant ones
-- Recognize and thank people who help their peers
+- Recognise and thank people who help their peers
 
 ---
 

--- a/docs/business-resources/ai-learning-development-directory.md
+++ b/docs/business-resources/ai-learning-development-directory.md
@@ -56,7 +56,7 @@ Each resource includes details on **format, eligibility, cost, and difficulty le
 #### 3. [Digital Transformation – Manufacturing AI Support](https://www.minister.industry.gov.au/ministers/husic/media-releases/free-ai-training-and-advice-small-medium-businesses)  
 *Advanced Robotics Manufacturing Hub & partners*
 
-- **Description:** Sector-focused advisory addressing AI-driven workflow optimization, robotics integration, and governance for manufacturing, energy, or agri SMEs.  
+- **Description:** Sector-focused advisory addressing AI-driven workflow optimisation, robotics integration, and governance for manufacturing, energy, or agri SMEs.  
 - **Format:** One-on-one advisory and hub-based support.  
 - **Eligibility:** Manufacturing, energy, agriculture SMEs.  
 - **Cost:** **Subsidised** (often free).  

--- a/docs/business-resources/ai-vendor-selection-guide.md
+++ b/docs/business-resources/ai-vendor-selection-guide.md
@@ -189,7 +189,7 @@ Before committing to a vendor, get clear answers to these questions:
 
 The [AI Vendor Evaluation Template](../governance-templates/ai-vendor-evaluation-checklist.md) helps you score vendors consistently, track your evaluation process, document decisions, and share assessments across your team.
 
-The template covers technical capability, Australian compliance, integration and support, transparency, costs, and references. Customize the weighting based on your priorities – not all criteria matter equally for every use case.
+The template covers technical capability, Australian compliance, integration and support, transparency, costs, and references. Customise the weighting based on your priorities – not all criteria matter equally for every use case.
 
 ---
 
@@ -229,7 +229,7 @@ The template covers technical capability, Australian compliance, integration and
 - Score vendors consistently
 - Document your evaluation
 - Share assessments across team
-- Customize weighting for your priorities
+- Customise weighting for your priorities
 
 **Remember:**
 Vendor selection is not just about features and price. Support quality, transparency, and alignment with Australian compliance requirements often matter more than marginal technical differences. Choose a partner who will help you succeed, not just a tool to license.

--- a/docs/governance-templates/ai-project-register.md
+++ b/docs/governance-templates/ai-project-register.md
@@ -64,7 +64,7 @@ This register provides a structured way to maintain a central record of all AI i
 |  | Sunset Date | Planned decommission | 1 Feb 2028 |
 | **Ethics** | Ethics Review | Status of ethical assessment | Completed - Low Risk |
 |  | Bias Testing | Results of bias evaluation | Passed all criteria |
-| **Benefits** | Benefits Realized | Actual vs planned benefits | 35% efficiency (target 40%) |
+| **Benefits** | Benefits Realised | Actual vs planned benefits | 35% efficiency (target 40%) |
 | **Monitoring & Updates** | Version History | Track model releases or changes | v1.0 (Aug 2025), v1.1 (Oct 2025) |
 |  | Performance Metrics | Agreed KPIs or benchmarks | Accuracy >85%, CSAT >90% |
 |  | Change Log | Notes of updates, retraining, risks | Retrained with new dataset Sep 2025 |

--- a/docs/governance-templates/ai-risks-by-industry.md
+++ b/docs/governance-templates/ai-risks-by-industry.md
@@ -149,7 +149,7 @@ These examples help businesses identify context-specific risks before adapting t
 
 | **Risk ID** | **Risk Name** | **Description** | **Potential Impact** |
 |--------------|----------------|-----------------|----------------------|
-| TL1 | **Route Optimization Safety Failures** | AI routing algorithms prioritize efficiency over safety considerations or compliance. | Vehicle accidents, driver fatigue, Chain of Responsibility breaches, insurance claims. |
+| TL1 | **Route Optimisation Safety Failures** | AI routing algorithms prioritise efficiency over safety considerations or compliance. | Vehicle accidents, driver fatigue, Chain of Responsibility breaches, insurance claims. |
 | TL2 | **Predictive Maintenance Errors** | Incorrect AI predictions about vehicle or equipment maintenance needs. | Vehicle breakdowns, service disruption, safety incidents, increased repair costs. |
 | TL3 | **Driver Monitoring Privacy Issues** | AI systems monitoring driver behaviour breach privacy or workplace surveillance obligations. | Privacy complaints, employee relations issues, Fair Work concerns, trust erosion. |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ Subscribe today for practical tools to make AI safe — and work for your growth
 - [Policy & Template Library](governance-templates/policy-template-library.md) - Central repository of all governance templates
 - [AI Readiness Checklist](governance-templates/ai-readiness-checklist.md) - Step-by-step readiness assessment for AI implementation
 - [AI Use Policy](governance-templates/ai-use-policy.md) - Comprehensive policy template for AI usage in organisations
-- [AI Incident Report Form](governance-templates/ai-incident-report-form.md) - Standardized incident reporting and response template
+- [AI Incident Report Form](governance-templates/ai-incident-report-form.md) - Standardised incident reporting and response template
 - [AI Risk Assessment Checklist](governance-templates/ai-risk-assessment-checklist.md) - Systematic risk evaluation framework
 - [AI Vendor Evaluation Checklist](governance-templates/ai-vendor-evaluation-checklist.md) - Vendor selection and evaluation criteria
 - [AI Project Register](governance-templates/ai-project-register.md) - Project tracking and governance oversight template

--- a/docs/safety-standards/international-ai-legal-overview.md
+++ b/docs/safety-standards/international-ai-legal-overview.md
@@ -63,7 +63,7 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 
 ### Canada
 **Status & scope:** Bill C-27 (which included the federal Artificial Intelligence and Data Act, AIDA) died on the Order Paper on 6 January 2025 when Parliament was prorogued. The bill would need to be completely re-introduced in a future parliamentary session. In June 2025, Minister Evan Solomon confirmed AIDA will not return in its original form, signaling a "light, tight, right" approach to any future AI regulation. Status remains highly uncertain as of October 2025.
-**What to do:** No federal AI-specific law is imminent. Continue monitoring for potential re-introduction under a new government. Organizations can still reference AIDA's former companion guidance for voluntary best practices (risk-based duties for "high-impact" systems, impact assessments, incident reporting), but recognize any future legislation may differ substantially.
+**What to do:** No federal AI-specific law is imminent. Continue monitoring for potential re-introduction under a new government. Organizations can still reference AIDA's former companion guidance for voluntary best practices (risk-based duties for "high-impact" systems, impact assessments, incident reporting), but recognise any future legislation may differ substantially.
 
 ### United Kingdom (UK)
 **Status & scope:** **No single AI Act**; the UK follows a **contextual, regulator-led** approach under the **Government Response (Feb 2024)** to its AI White Paper. Central functions coordinate regulators; the **UK AI Safety Institute** evaluates advanced systems and supports guidance/testing.  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
   - Glossary: glossary.md
   - AI Safety & Standards:
       - Relevant Australian Legislation: safety-standards/ai-australian-legislation.md
+      - Guidance for AI Adoption (AI6): safety-standards/guidance-for-ai-adoption-ai6.md
       - Voluntary AI Safety Standard (10 Guardrails): safety-standards/voluntary-ai-safety-standard-10-guardrails.md
       - International AI Legal Overview: safety-standards/international-ai-legal-overview.md
   - Governance Templates:


### PR DESCRIPTION
Updated 7 markdown files to ensure consistent Australian English spelling throughout the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardises Australian English spelling across multiple docs and adds AI6 guidance to site navigation.
> 
> - **Documentation**:
>   - Standardise en-AU spelling across key pages: `business-resources/ai-change-management.md`, `ai-learning-development-directory.md`, `ai-vendor-selection-guide.md`, `governance-templates/ai-project-register.md`, `ai-risks-by-industry.md`, `safety-standards/international-ai-legal-overview.md`, and `index.md` (e.g., recognise/optimise/realised; standardised descriptions).
> - **Site navigation**:
>   - Add `Guidance for AI Adoption (AI6)` to `mkdocs.yml` under `AI Safety & Standards`.
>   - Keep existing links updated to reflect standardised terminology (e.g., “Standardised” in `AI Incident Report Form` description).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6776c4089fc849b97fc0d3bfcd60da4c4e416d6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->