### PR TITLE
Add SafeAI-Aus Knowledge Assistant chat widget

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -61,3 +61,25 @@
   </script>
   {% endif %}
 {% endblock %}
+
+{% block content %}
+  {{ super() }}
+
+  <!-- SafeAI-Aus Knowledge Assistant Chat Widget -->
+  <div id="airia-chat-root"></div>
+  <script type="module">
+    import AiriaChat from "https://prodaus.embed-api.airia.ai/get-chat-embed.js"
+    AiriaChat.init({
+      pipelineId: "082a8566-0662-4ce1-83fb-42503ac7fb64",
+      apiKey: "ak-MTk2NTI1MjYwNnwxNzY3MzUxOTcwNzczfHRpLWMybHRjR3hsWm5rdVlXa3R8MXw5MTE4ODgyMTQg",
+      apiUrl: "https://prodaus.embed-api.airia.ai",
+      greeting: "Hi! I can help you find AI safety resources and answer questions about Australian AI governance. What would you like to know?",
+      imagePath: "{{ base_url }}/assets/safeaiaus-logo-600px.png",
+      imageSize: "medium",
+      imageBgColor: "#FFFFFF",
+      imageBorderColor: "#0b6428",
+      imageBorderWidth: "3px",
+      autoOpen: false
+    })
+  </script>
+{% endblock %}


### PR DESCRIPTION
Integrate Airia AI chat widget to provide interactive assistance with AI safety resources and Australian AI governance questions.

Features:
- Custom greeting tailored to SafeAI-Aus content
- SafeAI-Aus branded icon (logo)
- Fixed position bottom-right placement
- Auto-open disabled for non-intrusive UX

Technical notes:
- Widget initialised with Airia pipeline configuration
- API key rate-limited in Airia dashboard
- Additional styling customisation pending Airia support response

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates the Airia chat widget to provide on-site assistance for AI safety and Australian AI governance.
> 
> - Injects widget in `overrides/main.html` `content` block with `<div id="airia-chat-root">` and module script
> - Initializes `AiriaChat` with `pipelineId`, `apiUrl`, `apiKey`, custom `greeting`, and SafeAI-Aus branding (`imagePath`, size/colors/border)
> - Sets `autoOpen: false` for non-intrusive behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdc1e0f567083a70e3966476cfa4fda4a9ce2b0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->