### PR TITLE
Align CI/docs to Zensical and fix sitemap generation on Python 3.10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,17 +24,21 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install git+https://github.com/zensical/zensical.git
+          pip install -r requirements.txt
       - name: Build site
         run: zensical build
       - name: Generate sitemap.xml
         run: |
           python - << 'PY'
-          import os, re, tomllib
+          import os, re
+          try:
+              import tomllib
+          except ModuleNotFoundError:  # Python < 3.11
+              import tomli as tomllib
           import xml.etree.ElementTree as ET
 
           # Extract site_url from zensical.toml

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ SafeAI-Aus provides practical resources, frameworks, and insights to help Austra
 - **Responsible** — transparent, fair, and accountable  
 - **Growth-focused** — unlocking productivity and innovation for Australia's future  
 
-This repository powers the SafeAI-Aus knowledge hub, built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).  
+This repository powers the SafeAI-Aus knowledge hub, built with [Zensical](https://github.com/zensical/zensical).  
 
 ---
 
 ## What's inside  
-- **`mkdocs.yml`** — site configuration (theme, navigation, metadata, search, sitemap)  
+- **`zensical.toml`** — site configuration (theme, navigation, metadata, search, sitemap)  
 - **`docs/`** — all content in Markdown organized into three main areas:
   - **AI Safety & Standards** — Australian legislation, voluntary safety standards, international legal overview
   - **Governance Templates** — practical policy templates, checklists, and forms for AI implementation
@@ -43,7 +43,7 @@ Our knowledge hub includes:
 Contributions are welcome — from fixing typos to adding new resources.  
 
 - Add or edit pages in `docs/` (Markdown format).  
-- Sidebar structure is defined in `mkdocs.yml` under `nav:`.  
+- Sidebar structure is defined in `zensical.toml` under `nav:`.  
 - Page titles come from the first `# Heading` in each file.  
 
 👉 Please keep content aligned with the project's mission: *safe, responsible, and growth-focused AI for Australia.*  
@@ -65,7 +65,7 @@ To preview changes before pushing:
 python3 -m venv .venv
 source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
-mkdocs serve
+zensical serve
 ```
 
 Then open [http://127.0.0.1:8000/](http://127.0.0.1:8000/) in your browser.  
@@ -74,8 +74,8 @@ Then open [http://127.0.0.1:8000/](http://127.0.0.1:8000/) in your browser.
 
 ## Deployment  
 - Pushing to `main` automatically triggers a GitHub Actions build.  
-- The site is published to the `gh-pages` branch.  
-- GitHub Pages is configured to serve from `gh-pages`.  
+- The site is published via GitHub Actions (Pages deploy workflow).  
+- GitHub Pages is configured to deploy from GitHub Actions.  
 
 ---
 


### PR DESCRIPTION
### Motivation
- Align CI and local environment to the pinned Zensical install to avoid mismatches between local/dev builds and GitHub Actions.
- Ensure the sitemap generation step does not fail on runners using Python 3.10 where the built-in `tomllib` is not available.

### Description
- Update the GitHub Actions workflow to use `python-version: '3.10'` and install dependencies with `pip install -r requirements.txt` instead of installing Zensical directly from the repo.
- Add a fallback import in the inline sitemap generation script to load `tomli` when `tomllib` is not present (`try: import tomllib` / `except ModuleNotFoundError: import tomli as tomllib`).
- Update `README.md` to reference `zensical.toml`, replace `mkdocs` mentions with `Zensical`, and change local preview instructions to use `zensical serve`.

### Testing
- Ran `python -m pip install -r requirements.txt`, `zensical --help`, and `zensical build` previously for the docs migration which succeeded and produced a `site/` output directory.
- The sitemap fallback change is a workflow-only update and was not executed in CI as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b0bcfbb388325808e81ccbcbaca3d)