### PR TITLE
feat: Re-enable Airia chat widget and custom SEO templates

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -83,9 +83,7 @@ nav = [
 [project.theme]
 
 # Custom template directory for Airia widget and SEO overrides
-# TEMPORARILY DISABLED: Zensical requires full Material theme structure in custom_dir
-# Re-enable once template structure is properly set up
-# custom_dir = "overrides"
+custom_dir = "overrides"
 
 # Favicon and logo
 favicon = "assets/favicon.svg"


### PR DESCRIPTION
Enable custom_dir in zensical.toml to use overrides/main.html template. This restores:
- Airia AI chat widget for user support
- Custom SEO meta tags (OpenGraph, Twitter Cards)
- Enhanced favicon configuration
- Structured data (FAQ, HowTo schemas)

Tested locally - build succeeds and all features working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)