### PR TITLE
Improve chat widget styling

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -374,6 +374,19 @@ h3 {
     color: #adb5bd;
 }
 
+/* Airia chat widget tweaks */
+#airia-chat-root {
+    font-size: 16px;
+}
+
+#airia-chat-root *,
+#airia-chat-root button,
+#airia-chat-root input,
+#airia-chat-root textarea {
+    font-size: 1rem;
+    line-height: 1.5;
+}
+
 /* Print-friendly styles */
 @media print {
     .md-content {

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -177,7 +177,7 @@
       imagePath: "{{ base_url }}/assets/safeaiaus-logo-600px.png",
       imageSize: "medium",
       imageBgColor: "#FFFFFF",
-      imageBorderColor: "#0b6428",
+      imageBorderColor: "#4a4a4a",
       imageBorderWidth: "3px",
       autoOpen: false
     })


### PR DESCRIPTION
### Motivation
- Improve the chat widget's visibility and readability by using a neutral dark border for the avatar and increasing the widget's font size.

### Description
- Change `imageBorderColor` in `overrides/main.html` to `#4a4a4a` and add scoped CSS in `docs/stylesheets/extra.css` to raise the chat widget base `font-size` and associated element line-height.

### Testing
- Built and previewed the site locally with `zensical serve -a 0.0.0.0:8000` and captured a screenshot to confirm the visual updates, and the local server started and pages built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b2258ce988325944558f2838defb0)