### PR TITLE
Refine Zensical migration references

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -35,10 +35,7 @@ jobs:
         run: |
           python - << 'PY'
           import os, re
-          try:
-              import tomllib
-          except ModuleNotFoundError:  # Python < 3.11
-              import tomli as tomllib
+          import tomllib
           import xml.etree.ElementTree as ET
 
           # Extract site_url from zensical.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file is for AI coding and documentation agents working on this repository. 
 
 ## 1. Project overview
 
-- This repository powers the **SafeAI-Aus** static documentation site built with **Zensical** (Rust-based Material for MkDocs) and deployed via GitHub Pages.
+- This repository powers the **SafeAI-Aus** static documentation site built with **Zensical** and deployed via GitHub Pages.
 - Content lives primarily in `docs/`, with the Zensical configuration in `zensical.toml` and custom theme overrides in `overrides/`.
 - The focus is **practical AI safety, governance, and risk management for Australian organisations**.
 - Prefer small, incremental changes that keep the site easy for humans to maintain.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Zensical - Modern static site generator (Rust-based)
-# Migrated from MkDocs Material 9.7.1
+# Migrated to Zensical
 zensical

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,6 +1,6 @@
 # ============================================================================
 # SafeAI-Aus Zensical Configuration
-# Migrated from MkDocs Material to Zensical
+# Migrated to Zensical
 # ============================================================================
 
 [project]


### PR DESCRIPTION
### Motivation

- Remove leftover MkDocs-specific wording and clarify that the site uses Zensical.
- Simplify the Pages deployment to target a modern Python runtime and use the built-in TOML parser.

### Description

- Updated `AGENTS.md` to remove the phrase referencing MkDocs-based material and state the site is built with Zensical.
- Updated `zensical.toml` and `requirements.txt` to remove remaining MkDocs migration wording.
- Updated `.github/workflows/deploy.yml` to use `python-version: '3.11'` and import `tomllib` directly (removed the `tomli` fallback) for sitemap generation.

### Testing

- No automated tests were run for these documentation/configuration-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b15aed61c8325a83381548144ed5a)