### PR TITLE
Fix content accuracy in legislation and grants pages

### DIFF
--- a/docs/business-resources/ai-grants-funding-australia.md
+++ b/docs/business-resources/ai-grants-funding-australia.md
@@ -1,4 +1,5 @@
 ---
+icon: lucide/dollar-sign
 title: "AI Grants and Funding Opportunities for Australian Businesses"
 description: "Comprehensive guide to AI grants, funding programs, and financial support available for Australian businesses implementing AI responsibly. Includes federal, state, and industry programs."
 keywords: "AI grants Australia, AI funding Australia, AI business grants, Australian AI funding, AI government grants, AI business support, AI investment Australia, AI startup funding"
@@ -49,7 +50,7 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 ### R&D Tax Incentive
 
 - Provides **tax offsets to encourage companies to conduct eligible R&D activities that might not otherwise happen**.
-    - **43.5% refundable offset** for R&D entities with aggregated turnover under $20m (not controlled by exempt entities).
+    - **Refundable offset of 18.5% above the company tax rate** (e.g., 43.5% for companies paying 25% tax) for R&D entities with aggregated turnover under $20m (not controlled by exempt entities).
     - **Non‑refundable R&D intensity‑based offset** for larger companies (company tax rate plus a premium tied to R&D intensity).
 - Program is **active and ongoing**; the business.gov.au page does not state a last updated date.
 - ➡️ [Program overview](https://business.gov.au/grants-and-programs/research-and-development-tax-incentive)

--- a/docs/safety-standards/ai-australian-legislation.md
+++ b/docs/safety-standards/ai-australian-legislation.md
@@ -1,4 +1,5 @@
 ---
+icon: lucide/flag
 title: "Current Legal Landscape for AI in Australia"
 description: "Comprehensive overview of current legislation applicable to AI adoption in Australian business. Learn about Privacy Act, Consumer Law, Anti-Discrimination laws, and IP regulations affecting AI use."
 keywords: "AI legislation Australia, Australian AI law, AI privacy law, AI consumer law, AI discrimination law, AI intellectual property, AI legal compliance, Australian AI regulations, AI legal framework"
@@ -138,8 +139,8 @@ Australia's **IP laws**—covering copyright, patents, trademarks, and design ri
 - 📋 **Voluntary AI Safety Standard (VAISS) – 10 guardrails now integrated into AI6**
   The Voluntary AI Safety Standard, released in 2024, introduced 10 guardrails for safe and responsible AI. These guardrails remain relevant as a detailed control set and have been fully integrated into the Guidance for AI Adoption through an official "VAISS × implementation practices" crosswalk.
 
-- 🏛️ **National AI Plan and AI Safety Institute (from 2026)**
-  The National AI Plan (December 2025) sets a national roadmap to capture AI opportunities, spread benefits across the economy and keep Australians safe. The Government has paused work on standalone AI-specific legislation and mandatory guardrails, instead relying on existing "technology-neutral" laws and regulators, supported by a new **AI Safety Institute** from 2026 to monitor, test and advise on emerging AI risks.
+- 🏛️ **National AI Plan and AI Safety Institute (announced November 2025)**
+  The National AI Plan (December 2025) sets a national roadmap to capture AI opportunities, spread benefits across the economy and keep Australians safe. The Government has paused work on standalone AI-specific legislation and mandatory guardrails, instead relying on existing "technology-neutral" laws and regulators, supported by a new **AI Safety Institute** (announced November 2025, rolling out from early 2026) to monitor, test and advise on emerging AI risks.
 
 - 🔒 **Privacy Act reforms**
   Privacy reforms remain on the agenda, including stronger consent rules, potential rights to explanation for high-impact automated decisions, direct rights of action, and higher penalties. These reforms will significantly shape compliant AI data practices.


### PR DESCRIPTION
This commit corrects two factual inaccuracies found during content review:

1. AI Safety Institute timeline (ai-australian-legislation.md)
   - Clarified announcement date as November 2025
   - Updated rollout description to "announced November 2025, rolling out from early 2026"
   - Previous text stated "from 2026" without mentioning announcement

2. R&D Tax Incentive rate description (ai-grants-funding-australia.md)
   - Changed from "43.5% refundable offset" to "Refundable offset of 18.5% above the company tax rate"
   - Added example: "(e.g., 43.5% for companies paying 25% tax)"
   - Previous description was technically inaccurate as rate varies with company tax rate