### PR TITLE
Centre listmonk newsletter form

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -270,9 +270,10 @@ h3 {
     padding: 1.5rem;
     border-radius: 6px;
     border: 1px solid #dee2e6;
-    margin: 1.5rem 0;
+    margin: 1.5rem auto;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     max-width: 600px;
+    width: 100%;
 }
 
 .listmonk-form h3 {
@@ -801,11 +802,4 @@ h3 {
         grid-template-columns: 1fr;
         gap: 2rem;
     }
-}
-
-/* Additional centering for listmonk form */
-.listmonk-form {
-    display: flex;
-    justify-content: center;
-    width: 100%;
 }


### PR DESCRIPTION
### Motivation
- Ensure the Listmonk newsletter subscribe form on the homepage is visually centred and constrained so it aligns with the page layout.

### Description
- Update `docs/stylesheets/extra.css` to set `.listmonk-form { margin: 1.5rem auto; max-width: 600px; width: 100%; }` and remove the redundant flex-based centring override.

### Testing
- Started the local preview with `zensical serve --dev-addr 0.0.0.0:8000` and captured a visual check via Playwright which produced `artifacts/newsletter-center.png`, both operations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e175859a8832592974200af27c729)