### PR TITLE
feat: Add agent-readable update infrastructure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -92,6 +94,8 @@ jobs:
 
           ET.ElementTree(urlset).write(os.path.join(site_dir, 'sitemap.xml'), encoding='utf-8', xml_declaration=True)
           PY
+      - name: Generate updates.json
+        run: python scripts/generate_updates.py
       - name: Copy root-level files
         run: |
           cp robots.txt site/
@@ -103,6 +107,8 @@ jobs:
           test -f site/sitemap.xml || { echo "Error: site/sitemap.xml not found"; exit 1; }
           test -f site/robots.txt || { echo "Error: site/robots.txt not found"; exit 1; }
           test -f site/llms.txt || { echo "Error: site/llms.txt not found"; exit 1; }
+          test -f site/llms-full.txt || { echo "Error: site/llms-full.txt not found"; exit 1; }
+          test -f site/updates.json || { echo "Error: site/updates.json not found"; exit 1; }
           echo "Build verification passed"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .env
 .DS_Store
 **/.DS_Store
+__pycache__/
 sitemap.xml
 /working/
 /docs/brainstorms/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 **/.DS_Store
 sitemap.xml
 /working/
+/docs/brainstorms/
+/docs/plans/
 
 # Claude Code local settings (not tracked)
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,207 +1,63 @@
-# CLAUDE.md
+# SafeAI-Aus Public Website
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Project Overview
-
-SafeAI-Aus is a knowledge hub website providing practical resources, frameworks, and guidance for safe and responsible AI adoption in Australia. The site is built using **Zensical** (a Rust-based static site generator, formerly MkDocs Material) and deployed to GitHub Pages.
+Knowledge hub for safe and responsible AI adoption in Australia. Built with **Zensical** (Rust-based static site generator), deployed to GitHub Pages.
 
 **Live site:** https://safeaiaus.org/
+**Branch:** `main` (auto-deploys via GitHub Actions)
 
-## Development Commands
+## Development
 
-### Local Development
-
-**IMPORTANT:** Use the `.venv-py312` virtual environment (Python 3.12) for local development.
+**CRITICAL:** Always use `.venv-py312` (Python 3.12), not `.venv`.
 
 ```bash
-# Create/activate the Python 3.12 virtual environment
-python3.12 -m venv .venv-py312
-source .venv-py312/bin/activate   # Windows: .venv-py312\Scripts\activate
-
-# Install/upgrade dependencies (if needed)
-pip install -r requirements.txt
-
-# Serve site locally (with live reload)
-zensical serve
-# Opens at http://localhost:8000/
-
-# Build static site
-zensical build
-# Output goes to site/ directory
+source .venv-py312/bin/activate
+zensical serve                    # http://localhost:8000 (live reload)
+zensical build                    # Output to site/
+pip install -r requirements.txt   # If zensical not found
 ```
 
-**Note:** Zensical is a Rust-based binary distributed as a Python wheel. The binary requires Python 3.10+ to install properly from the wheel.
+## Content Structure
 
-### Content Management
+All content is Markdown in `docs/`. Navigation is defined in `zensical.toml` (not file structure).
 
-All content is in Markdown format within the `docs/` directory. The site has these main content areas:
+| Section | Path | Content |
+|---------|------|---------|
+| Safety & Standards | `docs/safety-standards/` | Australian legislation, VAISS, international overview |
+| Governance Templates | `docs/governance-templates/` | 11 templates aligned with VAISS |
+| Business Resources | `docs/business-resources/` | Grants, tools, learning directory |
+| Resources | `docs/resources/` | Glossary, community page |
 
-1. **AI Safety & Standards** (`docs/safety-standards/`)
-   - Australian legislation and voluntary safety standards
-   - International legal overview
+## Key Files
 
-2. **Governance Templates** (`docs/governance-templates/`)
-   - Ready-to-use policy templates, checklists, risk registers, forms
-   - 11 total templates aligned with VAISS (Voluntary AI Safety Standard)
+| File | Purpose |
+|------|---------|
+| `zensical.toml` | Site config, nav structure, theme |
+| `overrides/main.html` | Custom Jinja2 template (SEO, JSON-LD, favicons, frontmatter metadata) |
+| `docs/stylesheets/extra.css` | Custom CSS (header, nav, newsletter form, dark mode) |
+| `docs/assets/extra.js` | Umami analytics, canonical URLs |
+| `.github/workflows/deploy.yml` | CI/CD — builds, generates sitemap, deploys to Pages |
 
-3. **Business Resources** (`docs/business-resources/`)
-   - Grants and funding opportunities
-   - Tools, frameworks, state/territory resources
-   - Learning and development directory
+## Integrations (Do Not Modify Without Authorization)
 
-4. **Resources** (`docs/resources/`)
-   - Glossary
-   - Australian AI Community page
-
-## Architecture and Key Files
-
-### Configuration
-
-**`zensical.toml`** - Main site configuration
-- Site metadata (name, description, URLs)
-- Navigation structure (the `nav` array defines sidebar hierarchy)
-- Theme settings (color schemes, features, icons)
-- Custom CSS/JS paths
-- Repository and social media links
-
-**Important:** Navigation structure is defined in `zensical.toml` under `nav`, NOT in file structure. To add/remove/reorganize sidebar items, edit this file.
-
-### Custom Templates and Assets
-
-**`overrides/main.html`** - Custom Jinja2 template extending Zensical's base
-- Enhanced SEO metadata (OpenGraph, Twitter cards)
-- Structured data (JSON-LD) for search engines
-- Custom favicon handling
-- Canonical URL management
-- Frontmatter-driven metadata (title, description, keywords, og_image, etc.)
-
-**`docs/stylesheets/extra.css`** - Custom CSS
-- Header styling to match logo background (#F6F3EF light mode, #2d2d2d dark mode)
-- Navigation tabs styling
-- Improved heading hierarchy and readability
-- Listmonk newsletter form styling (centered, responsive)
-- Dark mode overrides
-
-**`docs/assets/extra.js`** - Custom JavaScript
-- Umami analytics integration
-- Canonical URL helpers
-- Prevents multiple analytics script injections
-
-**`docs/assets/performance-safe.js`** - Performance optimizations
-
-### Airia AI Chatbot Integration
-
-**SafeAI-Aus Knowledge Assistant**
-
-The site includes an AI-powered chat widget using [Airia](https://airia.ai/) to help visitors find resources and answer questions about Australian AI governance. The integration is configured in `overrides/main.html` (content block).
-
-Chat widget configuration:
-- **Greeting:** Welcomes users and offers to help find AI safety resources
-- **Logo:** Uses compressed SafeAI-Aus chat logo (`assets/safeai-aus-chat-logo-compressed.png`)
-  - Optimized to 200x200px, 58KB (compressed from original 2048x2048px, 5.9MB)
-  - **Important:** Chat widget logos should be small (under 100KB) for performance
-- **Image Settings:** Medium size, white background, green border (#0b6428, 3px)
-- **Auto Open:** `false` (widget appears as a button, opens on click)
-
-The chatbot is powered by Airia's pipeline system and provides context-aware responses based on the site's content.
-
-**Do not modify** the Airia configuration without coordination with the Airia administrator.
-
-**Image Optimization Note:** When adding new logos or images for the chat widget, always compress them significantly. Use Python Pillow to resize and optimize:
-```python
-from PIL import Image
-img = Image.open("original.png")
-img_resized = img.resize((200, 200), Image.Resampling.LANCZOS)
-img_resized.save("compressed.png", "PNG", optimize=True, quality=85)
-```
-
-### Newsletter Integration
-
-**Listmonk Newsletter Form**
-
-The site uses a self-hosted [Listmonk](https://listmonk.app/) instance for newsletter management:
-
-- **Form Action:** `https://lists.safeaiaus.org/subscription/form`
-- **List ID:** `48a923d4-0865-49f1-9c94-67a234cbcae3` (SafeAI-Aus list)
-- **Form Class:** `.listmonk-form` (styled in `extra.css`)
-
-Newsletter form appears on:
-- `docs/newsletter.md` (dedicated newsletter page)
-- `docs/index.md` (homepage footer section)
-
-The form includes:
-- Email field (required)
-- Name field (optional)
-- List checkbox (pre-checked for SafeAI-Aus list)
-- Privacy-focused (no third-party sharing)
-
-**Do not modify** the form action URL or list ID without coordination with the newsletter administrator.
-
-### Frontmatter Convention
-
-Each Markdown page can include YAML frontmatter for SEO and metadata:
-
-```yaml
----
-title: "Page Title"
-description: "Page description for meta tags"
-keywords: "comma, separated, keywords"
-author: "SafeAI-Aus"
-robots: "index, follow"
-og_title: "OpenGraph title"
-og_description: "OpenGraph description"
-og_type: "article"
-og_url: "https://safeaiaus.org/page-url/"
-og_image: "assets/custom-image.png"
-twitter_card: "summary_large_image"
-twitter_title: "Twitter card title"
-twitter_description: "Twitter card description"
----
-```
-
-The custom template in `overrides/main.html` reads these frontmatter values to generate proper SEO tags.
-
-## Deployment
-
-**GitHub Actions Workflow:** `.github/workflows/deploy.yml`
-
-- Triggers on push to `main` branch or manual workflow dispatch
-- Installs Python 3.12 and dependencies from `requirements.txt`
-- Runs `zensical build` to generate static site
-- Generates `sitemap.xml` using Python script (inline in workflow)
-- Copies `robots.txt`, `llms.txt`, and `llms-full.txt` to build output
-- Uploads to GitHub Pages via Actions artifact
-- GitHub Pages configured to deploy from GitHub Actions (not branch)
-
-**No manual deployment needed** - pushing to `main` triggers automatic build and deploy.
-
-### LLM Context Files
-
-The repo includes two files for AI crawlers and LLM systems:
-
-- **`llms.txt`** - Machine-readable policy declaring how LLMs may use this site's content (CC BY 4.0 with attribution)
-- **`llms-full.txt`** - Human-readable summary of the site's content, frameworks, and sections for LLM context
+- **Analytics:** Umami Cloud (configured in `extra.js`)
+- **Newsletter:** Listmonk self-hosted at lists.safeaiaus.org (form in `newsletter.md` and `index.md`)
+- **AI Chat Widget:** Airia chatbot (configured in `overrides/main.html`)
 
 ## Content Guidelines
 
-### Structure
+- Australian English, plain language, practical and actionable
+- Professional tone for governance templates, approachable for business resources
+- Proper heading hierarchy (h1 > h2 > h3). Page title from first `# Heading`
+- OpenGraph images MUST use absolute URLs: `https://safeaiaus.org/assets/image.png`
+- Pages with time-sensitive info (grants, legislation) need periodic review
 
-- Page titles come from the first `# Heading` in each Markdown file
-- Use proper heading hierarchy (h1 → h2 → h3)
-- Include frontmatter for important pages (especially landing pages and governance templates)
+### Frontmatter
 
-### Style
+Include YAML frontmatter for SEO on important pages (title, description, keywords, og_* fields). Template in `overrides/main.html` reads these values.
 
-- Written in plain English for Australian audiences
-- Focus on practical, actionable guidance
-- Align with project mission: safe, responsible, and growth-focused AI for Australia
-- Professional tone for governance templates (minimal emoji use)
-- More approachable tone for business resources
+### Template License Footer
 
-### Templates License Footer
-
-Governance templates include a standardized disclaimer and CC BY 4.0 license footer. Use collapsible admonition format:
+Governance templates must include this collapsible disclaimer:
 
 ```markdown
 ??? info "Disclaimer & Licence - Click to expand"
@@ -210,87 +66,16 @@ Governance templates include a standardized disclaimer and CC BY 4.0 license foo
     **Licence:** Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). You may copy, adapt, and redistribute with attribution: *"Source: SafeAI-Aus (safeaiaus.org)"*
 ```
 
-## Common Patterns
-
-### Adding New Content
+## Adding Content
 
 1. Create Markdown file in appropriate `docs/` subdirectory
 2. Add frontmatter (copy from similar page)
-3. Update `zensical.toml` navigation structure if needed
-4. Include proper heading hierarchy
-5. Add disclaimer/license footer for templates
-
-### Testing Changes
-
-```bash
-# ALWAYS activate the Python 3.12 venv
-source .venv-py312/bin/activate
-
-# Serve locally and check changes
-zensical serve
-
-# Build to verify no errors
-zensical build
-```
-
-### Editing Navigation
-
-Edit the `nav` array in `zensical.toml`. Structure:
-
-```toml
-nav = [
-  { "Section Name" = [
-    { "Page Name" = "path/to/file.md" },
-    { "Subsection" = [
-      { "Nested Page" = "path/to/nested.md" },
-    ]},
-  ]},
-]
-```
+3. Update `zensical.toml` nav if needed
+4. Add disclaimer/license footer for templates
 
 ## Important Notes
 
-- **Python Environment:**
-  - **CRITICAL:** ALWAYS use `.venv-py312` (Python 3.12), NOT `.venv` (Python 3.9)
-  - Zensical binary requires Python 3.10+ to install from wheel
-  - If `zensical: command not found` error occurs, you're using the wrong venv or need to run `pip install -r requirements.txt`
-
-- **Zensical Setup:**
-  - Zensical is a Rust-based binary distributed as a Python wheel (cp310-abi3)
-  - Install via `pip install zensical` (requires Python 3.10+)
-  - Site was migrated from MkDocs Material to Zensical - some MkDocs features may not work
-
-- **Development Workflow:**
-  - Local server runs on `http://localhost:8000`
-  - Site auto-rebuilds on file changes when using `zensical serve`
-  - Build output goes to `site/` directory (gitignored)
-  - GitHub Actions uses Python 3.12 for CI/CD builds
-
-- **Asset Management:**
-  - Custom CSS in `docs/stylesheets/`
-  - Custom JS in `docs/assets/`
-  - Images in `docs/assets/`
-  - **Image Optimization:** Chat widget logos and icons should be compressed to <100KB
-  - Use Python Pillow for image resizing/compression
-
-- **Critical Integrations (Do Not Modify Without Authorization):**
-  - **Analytics:** Umami Cloud
-  - **Newsletter:** Listmonk self-hosted (lists.safeaiaus.org)
-  - **AI Chat Widget:** Airia chatbot (configuration in `overrides/main.html`)
-
-- **SEO & Content:**
-  - OpenGraph images MUST use absolute URLs: `https://safeaiaus.org/assets/image.png`
-  - Pages with time-sensitive info (grants, legislation) need periodic review
-  - Navigation structure is in `zensical.toml`, not file structure
-
-- **Local Working Directories (Not Tracked in Git):**
-  - `working/` - Local working files, drafts, planning documents
-  - `tmp/` - Temporary files (screenshots, build artifacts)
-  - `.venv-py312/` - Python virtual environment
-  - `.claude/settings.local.json` - Claude Code local settings
-  - All above are in `.gitignore` and should never be committed
-
-- **Documentation Best Practices:**
-  - **NEVER document API keys, credentials, or secrets in this file** - even if they are public/browser-side credentials, they don't belong in developer documentation
-  - Reference where credentials are configured (e.g., "in `overrides/main.html`") rather than listing actual values
-  - If you need to understand integration credentials, read the source files directly
+- Images for chat widget must be compressed to <100KB (use Python Pillow)
+- Never document API keys or credentials in this file — read source files directly
+- `llms.txt` and `llms-full.txt` provide AI crawler context (CC BY 4.0)
+- Gitignored: `working/`, `tmp/`, `.venv-py312/`, `site/`, `.claude/settings.local.json`

--- a/docs/business-resources/agent-readable-resources.md
+++ b/docs/business-resources/agent-readable-resources.md
@@ -1,0 +1,106 @@
+---
+icon: lucide/bot
+title: "Agent-Readable Resources for AI Systems"
+description: "Machine-readable files for AI agents to monitor Australian AI governance updates, check usage policies, and access the SafeAI-Aus knowledge base programmatically."
+keywords: "AI agent resources, machine-readable AI governance, llms.txt, updates feed, AI compliance monitoring, automated governance updates, Australian AI updates"
+author: "SafeAI-Aus"
+robots: "index, follow"
+og_title: "Agent-Readable Resources for AI Systems"
+og_description: "Machine-readable files for AI agents to monitor Australian AI governance updates"
+og_type: "article"
+og_url: "https://safeaiaus.org/business-resources/agent-readable-resources/"
+og_image: "assets/safeaiaus-logo-600px.png"
+twitter_card: "summary_large_image"
+twitter_title: "Agent-Readable Resources for AI Systems"
+twitter_description: "Machine-readable files for AI agents to monitor Australian AI governance updates"
+---
+
+# Agent-Readable Resources
+
+> **Purpose:** Machine-readable files for AI agents and automated systems to monitor SafeAI-Aus content
+> **Audience:** Organisations using AI agents for compliance monitoring, governance tracking, or research | **Time:** 10 minutes
+
+Organisations are increasingly using AI agents to monitor regulatory changes, track governance resources, and stay across updates that affect their AI posture. SafeAI-Aus publishes structured, machine-readable files so your agents can work with our content directly.
+
+---
+
+## Available Resources
+
+### Updates Feed — What's Changed
+
+**URL:** [https://safeaiaus.org/updates.json](https://safeaiaus.org/updates.json)
+
+A structured changelog of content changes across the site. Each entry includes the date, a summary of the change, which content areas were affected, and which pages were modified.
+
+Your agent can fetch this file, filter by content area (e.g., `governance-templates`, `safety-standards`, `business-resources`), and surface changes since a given date — without parsing HTML or checking git history.
+
+**Example entry:**
+
+```json
+{
+  "date": "2026-04-10",
+  "commit": "abc1234",
+  "type": "docs",
+  "summary": "Add federal AI resources section, new state offices and community groups",
+  "tags": ["business-resources", "resources"],
+  "files": ["business-resources/state-territory-ai-resources/"]
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `date` | When the change was made (ISO 8601) |
+| `commit` | Short commit hash for traceability |
+| `type` | Change type (`docs`, `feat`, `fix`, `update`) |
+| `summary` | Plain-language description of the change |
+| `tags` | Content areas affected |
+| `files` | Pages that were modified (site-relative paths) |
+
+The feed also includes metadata — `schema_version` for format compatibility and `last_updated` so your agent can detect whether the feed has changed since its last check.
+
+### Usage Policy — How AI Systems May Use This Content
+
+**URL:** [https://safeaiaus.org/llms.txt](https://safeaiaus.org/llms.txt)
+
+A structured policy file declaring how AI systems may use SafeAI-Aus content. Covers permissions (reading, indexing, training), attribution requirements, disclaimers, and brand protection.
+
+Key points:
+
+- All content is licensed under **CC BY 4.0** — attribution required
+- AI systems must not present SafeAI-Aus content as legal or regulatory advice
+- AI systems must not imply SafeAI-Aus endorsement of their products
+
+### Knowledge Base Summary — What's Here
+
+**URL:** [https://safeaiaus.org/llms-full.txt](https://safeaiaus.org/llms-full.txt)
+
+A structured summary of the site's content — governance templates, legislation guides, business resources, and key frameworks. Useful for agents that need an overview of what SafeAI-Aus covers without crawling every page.
+
+---
+
+## How to Use These Resources
+
+### Compliance Monitoring
+
+Point your compliance agent at `/updates.json` and filter for `safety-standards` or `governance-templates` tags. When Australian legislation or standards change, the feed will show what was updated and when.
+
+### Template Tracking
+
+If your organisation has adopted SafeAI-Aus governance templates, your agent can check `/updates.json` for entries tagged `governance-templates` to know when templates have been revised.
+
+### General AI Assistants
+
+AI assistants answering questions about Australian AI governance can fetch `/llms-full.txt` for a current overview, and check `/updates.json` for recent changes that might affect their answers.
+
+---
+
+## Technical Details
+
+- **Format:** JSON (`updates.json`), TOML-like text (`llms.txt`), Markdown (`llms-full.txt`)
+- **Update frequency:** The updates feed is regenerated on every site deployment
+- **History:** The feed contains the full history of content changes — no rolling window or truncation
+- **Licence:** All content is [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Attribution: *"Source: SafeAI-Aus (safeaiaus.org)"*
+- **Cross-references:** Each file references the others, so discovering any one file leads to the rest
+
+!!! info "Discovery"
+    All three files are linked from each other and from this page. The `llms.txt` file is also referenced in our `robots.txt`. If your agent knows to check any one of these files, it can find the others.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -84,10 +84,20 @@ Practical adoption support:
 When using this content, attribute as:
 "Source: SafeAI-Aus (safeaiaus.org), licensed CC BY 4.0"
 
+## Machine-Readable Resources
+
+SafeAI-Aus provides structured files for AI agents and automated systems:
+
+- **Updates feed:** https://safeaiaus.org/updates.json — structured changelog of content changes, filterable by content area and date. Schema version 1, JSON format
+- **Usage policy:** https://safeaiaus.org/llms.txt — permissions, attribution requirements, and licensing terms for AI systems
+- **This file:** https://safeaiaus.org/llms-full.txt — knowledge base summary
+
+Agents can poll `/updates.json` to discover what has changed since their last visit without parsing HTML or git history.
+
 ## Contact
 
 - Email: contact@safeaiaus.org
 - GitHub: github.com/safeai-aus/safeai-aus.github.io
 
 ---
-Last updated: 2026-01-31
+Last updated: 2026-04-15

--- a/llms.txt
+++ b/llms.txt
@@ -7,9 +7,9 @@ contact = "contact@safeaiaus.org"
 license = "CC BY 4.0"
 repo = "https://github.com/safeai-aus/safeai-aus.github.io"
 website = "https://safeaiaus.org"
-policy-version = "1.1"
-last-updated = "2026-01-31"
-changelog = "https://github.com/safeai-aus/safeai-aus.github.io/commits/main/llms.txt"
+policy-version = "1.2"
+last-updated = "2026-04-15"
+changelog = "https://safeaiaus.org/updates.json"
 full-summary = "https://safeaiaus.org/llms-full.txt"
 
 [defaults]
@@ -27,19 +27,14 @@ prohibit = "endorsement-implied, brand-impersonation"
 allowed-content = [
   "docs/**.md",
   "docs/**.yml",
-  "site/**",
-  "templates/**.md",
-  "templates/**.docx",
-  "templates/**.xlsx",
-  "assets/**.svg",
-  "assets/**.png"
+  "docs/assets/**.svg",
+  "docs/assets/**.png",
+  "site/**"
 ]
 
 disallowed-content = [
   ".github/**",
-  "private/**",
-  "data/synthetic/**",   # example; adjust to your structure
-  "vendor/**"
+  "private/**"
 ]
 
 conditions = [

--- a/scripts/generate_updates.py
+++ b/scripts/generate_updates.py
@@ -21,11 +21,14 @@ from typing import List
 # Conventional commit prefix pattern
 PREFIX_PATTERN = re.compile(r"^(\w+)(?:\(.+?\))?:\s+(.+)$")
 
-# Known conventional commit prefixes
+# Prefixes that map to their own type in the feed schema
+AGENT_FACING_TYPES = {"docs", "feat", "fix"}
+
+# All recognised conventional commit prefixes (others map to "update")
 KNOWN_PREFIXES = {"docs", "feat", "fix", "style", "chore", "refactor", "perf", "test", "ci", "build"}
 
-# Directories under docs/ to exclude (internal working files)
-EXCLUDED_DIRS = {"plans", "brainstorms"}
+# Directories under docs/ to exclude (internal working files and legacy paths)
+EXCLUDED_DIRS = {"plans", "brainstorms", "templates"}
 
 
 @dataclass
@@ -69,9 +72,15 @@ def read_site_url() -> str:
 
 
 def get_commit_hashes() -> List[str]:
-    """Return commit hashes in reverse chronological order (newest first)."""
+    """Return commit hashes in reverse chronological order (newest first).
+
+    Uses ``--first-parent`` to follow the main branch lineage without
+    descending into merged branches (which would cause duplicates).
+    Merge commits are *included* — ``get_changed_md_files`` diffs them
+    against their first parent, capturing the combined effect of the merge.
+    """
     result = subprocess.run(
-        ["git", "log", "--first-parent", "--no-merges", "--format=%H"],
+        ["git", "log", "--first-parent", "--format=%H"],
         capture_output=True, text=True, check=True,
     )
     return [h for h in result.stdout.strip().splitlines() if h]
@@ -89,12 +98,31 @@ def get_commit_info(commit_hash: str) -> tuple[str, str]:
     return commit_date, subject
 
 
-def get_changed_md_files(commit_hash: str) -> List[str]:
-    """Return list of docs/**/*.md files changed in a commit."""
+def _is_merge_commit(commit_hash: str) -> bool:
+    """Check if a commit has more than one parent."""
     result = subprocess.run(
-        ["git", "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", commit_hash],
-        capture_output=True, text=True, check=True,
+        ["git", "rev-parse", f"{commit_hash}^2"],
+        capture_output=True, text=True,
     )
+    return result.returncode == 0
+
+
+def get_changed_md_files(commit_hash: str) -> List[str]:
+    """Return list of docs/**/*.md files added or modified in a commit.
+
+    For merge commits, diffs against the first parent to capture the
+    combined effect of the merge. Deleted files are excluded so the
+    feed does not emit dead URLs.
+    """
+    # For merge commits, diff against first parent; for regular commits
+    # use --root to handle the initial commit
+    if _is_merge_commit(commit_hash):
+        cmd = ["git", "diff-tree", "--no-commit-id", "--name-only",
+               "--diff-filter=d", "-r", f"{commit_hash}^1", commit_hash]
+    else:
+        cmd = ["git", "diff-tree", "--root", "--no-commit-id", "--name-only",
+               "--diff-filter=d", "-r", commit_hash]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     files = []
     for line in result.stdout.strip().splitlines():
         if not line.startswith("docs/") or not line.endswith(".md"):
@@ -118,7 +146,9 @@ def parse_subject(subject: str) -> tuple[str, str]:
         prefix = match.group(1).lower()
         summary = match.group(2).strip()
         if prefix in KNOWN_PREFIXES:
-            return prefix, summary
+            # Only docs, feat, fix are agent-facing types; others → update
+            commit_type = prefix if prefix in AGENT_FACING_TYPES else "update"
+            return commit_type, summary
     return "update", subject
 
 

--- a/scripts/generate_updates.py
+++ b/scripts/generate_updates.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Generate updates.json from git commit history.
+
+Parses the git log for commits that modify Markdown content files
+(``docs/**/*.md``, excluding internal directories like ``docs/plans/``
+and ``docs/brainstorms/``), and produces a structured JSON changelog
+feed at ``site/updates.json``.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import List
+
+# Conventional commit prefix pattern
+PREFIX_PATTERN = re.compile(r"^(\w+)(?:\(.+?\))?:\s+(.+)$")
+
+# Known conventional commit prefixes
+KNOWN_PREFIXES = {"docs", "feat", "fix", "style", "chore", "refactor", "perf", "test", "ci", "build"}
+
+# Directories under docs/ to exclude (internal working files)
+EXCLUDED_DIRS = {"plans", "brainstorms"}
+
+
+@dataclass
+class ChangeEntry:
+    date: str
+    commit: str
+    type: str
+    summary: str
+    tags: List[str] = field(default_factory=list)
+    files: List[str] = field(default_factory=list)
+
+
+def check_git_history() -> None:
+    """Fail loudly if running in a shallow clone."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        capture_output=True, text=True, check=True,
+    )
+    if result.stdout.strip() == "true":
+        print(
+            "Error: shallow git clone detected. "
+            "The updates.json generator requires full history. "
+            "Set fetch-depth: 0 in the checkout step.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def read_site_url() -> str:
+    """Read and normalise site_url from zensical.toml."""
+    config_path = Path("zensical.toml")
+    if not config_path.exists():
+        print("Error: zensical.toml not found", file=sys.stderr)
+        sys.exit(1)
+
+    with open(config_path, "rb") as f:
+        config = tomllib.load(f)
+
+    url = config.get("project", {}).get("site_url", "")
+    return url.rstrip("/") + "/"
+
+
+def get_commit_hashes() -> List[str]:
+    """Return commit hashes in reverse chronological order (newest first)."""
+    result = subprocess.run(
+        ["git", "log", "--first-parent", "--no-merges", "--format=%H"],
+        capture_output=True, text=True, check=True,
+    )
+    return [h for h in result.stdout.strip().splitlines() if h]
+
+
+def get_commit_info(commit_hash: str) -> tuple[str, str]:
+    """Return (date, subject) for a commit."""
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%cd%n%s", "--date=short", commit_hash],
+        capture_output=True, text=True, check=True,
+    )
+    lines = result.stdout.strip().splitlines()
+    commit_date = lines[0] if lines else ""
+    subject = lines[1] if len(lines) > 1 else ""
+    return commit_date, subject
+
+
+def get_changed_md_files(commit_hash: str) -> List[str]:
+    """Return list of docs/**/*.md files changed in a commit."""
+    result = subprocess.run(
+        ["git", "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", commit_hash],
+        capture_output=True, text=True, check=True,
+    )
+    files = []
+    for line in result.stdout.strip().splitlines():
+        if not line.startswith("docs/") or not line.endswith(".md"):
+            continue
+        # Exclude internal directories
+        parts = line.split("/")
+        if len(parts) > 1 and parts[1] in EXCLUDED_DIRS:
+            continue
+        files.append(line)
+    return files
+
+
+def parse_subject(subject: str) -> tuple[str, str]:
+    """Parse a commit subject into (type, summary).
+
+    Recognises conventional commit prefixes like ``docs: summary``.
+    Falls back to type ``update`` with the full subject as summary.
+    """
+    match = PREFIX_PATTERN.match(subject)
+    if match:
+        prefix = match.group(1).lower()
+        summary = match.group(2).strip()
+        if prefix in KNOWN_PREFIXES:
+            return prefix, summary
+    return "update", subject
+
+
+def derive_tag(file_path: str) -> str:
+    """Derive a content-area tag from a file path.
+
+    Strips the ``docs/`` prefix and returns the first directory segment.
+    Files directly in ``docs/`` (e.g. index.md, about.md) get the tag
+    ``site`` to distinguish them from content-area pages.
+    """
+    rel = file_path.removeprefix("docs/")
+    parts = rel.split("/")
+    if len(parts) > 1:
+        return parts[0]
+    return "site"
+
+
+def file_to_site_path(file_path: str) -> str:
+    """Convert a repo file path to a site-relative URL path.
+
+    ``docs/governance-templates/ai-use-policy.md``
+    becomes ``governance-templates/ai-use-policy/``
+
+    ``docs/index.md`` becomes ``/`` (site root).
+    """
+    rel = file_path.removeprefix("docs/")
+    # Remove .md extension and add trailing slash for clean URLs
+    if rel.endswith(".md"):
+        rel = rel[:-3]
+    # index files become the directory path
+    if rel.endswith("/index") or rel == "index":
+        rel = rel.removesuffix("index")
+    else:
+        rel += "/"
+    # Root index produces empty string — normalise to "/"
+    return rel if rel else "/"
+
+
+def build_entries(commit_hashes: List[str]) -> List[ChangeEntry]:
+    """Build changelog entries from commit hashes."""
+    entries: List[ChangeEntry] = []
+
+    for full_hash in commit_hashes:
+        md_files = get_changed_md_files(full_hash)
+        if not md_files:
+            continue
+
+        commit_date, subject = get_commit_info(full_hash)
+        commit_type, summary = parse_subject(subject)
+        short_hash = full_hash[:7]
+
+        # Derive tags from file paths (deduplicated, sorted)
+        tags = sorted(set(derive_tag(f) for f in md_files))
+
+        # Convert file paths to site-relative URLs
+        site_files = sorted(set(file_to_site_path(f) for f in md_files))
+
+        entries.append(ChangeEntry(
+            date=commit_date,
+            commit=short_hash,
+            type=commit_type,
+            summary=summary,
+            tags=tags,
+            files=site_files,
+        ))
+
+    return entries
+
+
+def main() -> int:
+    check_git_history()
+    site_url = read_site_url()
+
+    commit_hashes = get_commit_hashes()
+    entries = build_entries(commit_hashes)
+
+    feed = {
+        "schema_version": 1,
+        "last_updated": date.today().isoformat(),
+        "site_url": site_url.rstrip("/"),
+        "related": {
+            "llms_txt": f"{site_url}llms.txt",
+            "llms_full_txt": f"{site_url}llms-full.txt",
+        },
+        "entries": [
+            {
+                "date": e.date,
+                "commit": e.commit,
+                "type": e.type,
+                "summary": e.summary,
+                "tags": e.tags,
+                "files": e.files,
+            }
+            for e in entries
+        ],
+    }
+
+    output_path = Path("site/updates.json")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(feed, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    print(f"Generated {output_path} with {len(entries)} entries")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zensical.toml
+++ b/zensical.toml
@@ -70,6 +70,7 @@ nav = [
     { "Government AI Resources" = "business-resources/state-territory-ai-resources.md" },
     { "AI Learning & Development Directory" = "business-resources/ai-learning-development-directory.md" },
     { "Australian AI Community" = "resources/australian-ai-community.md" },
+    { "Agent-Readable Resources" = "business-resources/agent-readable-resources.md" },
   ]},
 ]
 


### PR DESCRIPTION
## Summary

- Adds a structured changelog feed (`/updates.json`) auto-generated from git history at build time, so AI agents can discover content changes by date and content area
- Refreshes `llms.txt` (v1.2) and `llms-full.txt` with current content inventory and cross-references to the new feed
- New "Agent-Readable Resources" page under Business Resources explaining the files and how organisations can use them with their agents
- Deploy workflow: full git history checkout, new generator step, expanded build verification

## What this enables

An organisation's compliance agent, template-tracking assistant, or general AI assistant can fetch `/updates.json`, filter by content area (`governance-templates`, `safety-standards`, `business-resources`), and identify changes since a given date — without parsing HTML or git history.

## Key files

| File | Purpose |
|------|---------|
| `scripts/generate_updates.py` | Generator script — parses git log, filters to `docs/**/*.md`, produces JSON |
| `docs/business-resources/agent-readable-resources.md` | Human-facing explainer page |
| `.github/workflows/deploy.yml` | Workflow changes (fetch-depth, generator step, verify) |
| `llms.txt` | Refreshed to v1.2, changelog → updates.json |
| `llms-full.txt` | Added machine-readable resources section |

## Test plan

- [ ] Site builds without errors (`zensical build`)
- [ ] Generator produces valid JSON (`python scripts/generate_updates.py && python -m json.tool site/updates.json`)
- [ ] Feed entries match recent git history for content changes
- [ ] No non-content commits in feed (CI, config, CLAUDE.md excluded)
- [ ] `docs/plans/` and `docs/brainstorms/` excluded from feed
- [ ] New page renders correctly and appears in nav
- [ ] `llms.txt` changelog field points to `/updates.json`
- [ ] Cross-references work: each agent file links to the others
- [ ] Deploy workflow passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)