### PR TITLE
docs: April 2026 content updates from researcher digests

### DIFF
--- a/docs/business-resources/ai-aus-tools-frameworks.md
+++ b/docs/business-resources/ai-aus-tools-frameworks.md
@@ -4,6 +4,7 @@ title: "AI Tools & Frameworks for Australian Businesses"
 description: "Curated collection of AI tools, frameworks and resources for Australian businesses implementing AI safely and responsibly. Includes risk management, governance and technical testing tools."
 keywords: "AI tools Australia, AI frameworks Australia, AI risk management tools, AI governance tools, AI testing tools, Australian AI resources, AI safety tools, AI compliance tools"
 author: "SafeAI-Aus"
+last-reviewed: "2026-04-15"
 robots: "index, follow"
 og_title: "AI Tools & Frameworks for Australian Businesses"
 og_description: "Curated collection of AI tools, frameworks and resources for Australian businesses"
@@ -26,6 +27,29 @@ A curated list of practical tools, frameworks and resources to help Australian b
     **Scope:** Non-commercial resources only (government, standards bodies, nonprofits and open-source).
 
     **How to use:** Start with frameworks, set governance, then implement technical controls and monitoring.
+
+---
+
+## 🏛️ DTA AI Impact Assessment Tool (Commonwealth)
+
+In December 2025, the Digital Transformation Agency (DTA) overhauled its **Policy for the Responsible Use of AI in Government** (effective 15 December 2025). Alongside the updated policy, the DTA published two key resources:
+
+- **AI Impact Assessment Tool** – a 12-section fillable template aligned with the Australian Government's AI Ethics Principles. Designed for Commonwealth agencies but useful for any organisation wanting a structured impact assessment. ([digital.gov.au](https://www.digital.gov.au/ai/impact-assessment-tool/introduction))
+- **AI Procurement Guidance** – practical guidance for procuring AI products and services responsibly. ([dta.gov.au](https://www.dta.gov.au/media-releases/ai-policy-overhauled-new-impact-assessment-tool-and-procurement-guidance))
+
+**Key dates for Commonwealth agencies:**
+
+- **15 June 2026** – first mandatory requirements take effect
+- **December 2026** – all remaining requirements take effect
+
+!!! tip "Relevance beyond the Commonwealth"
+    While these requirements are mandatory only for Commonwealth agencies, they signal the direction for all Australian organisations. The Impact Assessment Tool is freely available and provides a solid starting point for any AI governance program.
+
+---
+
+## 🤖 GovAI Chat (APS AI Plan)
+
+As part of the **APS AI Plan 2025**, the Australian Government is trialling **GovAI Chat** – an AI assistant for Australian Public Service (APS) staff, with trials beginning in April 2026. This is not a tool organisations can access directly, but it signals growing government adoption of AI and may influence future standards and expectations. ([digital.gov.au](https://www.digital.gov.au/policy/ai/australian-public-service-ai-plan-2025/what-we-plan-achieve))
 
 ---
 

--- a/docs/business-resources/ai-grants-funding-australia.md
+++ b/docs/business-resources/ai-grants-funding-australia.md
@@ -5,7 +5,7 @@ description: "Comprehensive guide to AI grants, funding programs and financial s
 keywords: "AI grants Australia, AI funding Australia, AI business grants, Australian AI funding, AI government grants, AI business support, AI investment Australia, AI startup funding"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-01-31"
+last-reviewed: "2026-04-15"
 review-cycle: "quarterly"
 og_title: "AI Grants and Funding Opportunities for Australian Businesses"
 og_description: "Comprehensive guide to AI grants, funding programs and financial support for Australian businesses"
@@ -22,10 +22,14 @@ twitter_description: "Comprehensive guide to AI grants, funding programs and fin
 > **Purpose:** Comprehensive directory of AI grants, funding programs and financial support for Australian organisations
 > **Audience:** Business owners, CFOs, project managers and grant applicants | **Time:** 30-45 minutes
 
+!!! warning "Time-sensitive: Upcoming deadlines"
+    - **CRC Program Round 27** closes **21 April 2026** — [Apply now](https://business.gov.au/grants-and-programs/cooperative-research-centres-crc-grants)
+    - **CRC-P Round 19 (AI stream, $20M)** closes **12 May 2026** — [Apply now](https://business.gov.au/grants-and-programs/cooperative-research-centres-projects-crcp-grants)
+
 AI is reshaping industries across Australia. To support businesses in responsibly adopting and scaling AI, a mix of government grants, research programs and industry‑backed accelerators are available. This article provides a consolidated overview of the most relevant opportunities for Australian businesses today.
 
 !!! warning "Program status changes frequently"
-    Government programs open, close and change eligibility regularly. **Always verify current status** with the relevant funding body before investing time in an application. Last reviewed: January 2026.
+    Government programs open, close and change eligibility regularly. **Always verify current status** with the relevant funding body before investing time in an application. Last reviewed: April 2026.
 
 ---
 
@@ -34,9 +38,9 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 ### AI Adopt Program
 
 - Provided **$3–5 million over four years** for up to 50% of project costs.
-- Aimed at establishing **AI Adopt Centres** to help SMEs integrate responsible AI.
-- Currently **closed**, but future rounds may reopen.
-- ➡️ [Learn more](https://business.gov.au/grants-and-programs/artificial-intelligence-ai-adopt-program)
+- **AI Adopt Centres** are now operational across Australia through 2026/27, providing free specialist services to eligible SMEs including AI readiness assessments, implementation support and training.
+- The competitive grant round has **concluded**, but centre services are accessible to eligible businesses.
+- ➡️ [SME services](https://business.gov.au/expertise-and-advice/ai-adopt-centres) | [Program overview](https://business.gov.au/grants-and-programs/artificial-intelligence-ai-adopt-program)
 
 ### AI and Digital Capability Centres
 
@@ -49,7 +53,7 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 
 - Competitive grants between **$250,000 and $500,000** for regional businesses to develop and demonstrate AI solutions.
 - Required matched co‑funding and ran across three rounds.
-- Program **concluded**.
+- Program **concluded**. Round 1 listing remains on business.gov.au — verify eligibility and deadline directly.
 - ➡️ [Program details](https://business.gov.au/grants-and-programs/catalysing-the-artificial-intelligence-opportunity-in-our-regions-round-1?)
 
 ### R&D Tax Incentive
@@ -64,7 +68,7 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 
 - Competitive grants supporting research between universities and businesses.
 - **Discovery Projects**: $30k–$500k annually for up to 5 years.
-- **Linkage Projects**: Promote industry–academic partnerships; in 2024 Round 2, $46.6m was awarded to 75 projects.
+- **Linkage Projects**: Promote industry–academic partnerships; in 2024 Round 2, $46.6m was awarded to 75 projects. The 2026 Linkage Projects round closed 18 March 2026.
 - Program is **active and ongoing**.
 - ➡️ [Discovery Projects](https://www.arc.gov.au/funding-research/discovery-linkage/discovery-program/discovery-projects) | [Linkage Projects](https://www.arc.gov.au/funding-research/funding-schemes/linkage-program/linkage-projects)
 
@@ -92,13 +96,27 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 - Program is active.
 - ➡️ [More information](https://www.csiro.au/en/research/technology-space/ai/nsf-ai-research)
 
-### Cooperative Research Centres Projects (CRC-P) – AI Focus
+### Cooperative Research Centres Projects (CRC-P) – Round 19 AI Stream
 
-- Grants between $100,000 and $3 million for collaborative AI research projects.
-- Up to 3 years funding for industry-led AI collaborations.
-- Additional funding allocated specifically for AI projects in recent rounds.
-- Program is active with annual rounds.
+- Grants between **$100,000 and $3 million** for collaborative AI research projects, up to 3 years.
+- Round 19 includes a dedicated **$20 million funding stream** for projects that develop or enhance AI systems. Grants of $100,000–$3 million, up to 3 years, with 50% co-contribution required. **Closing 12 May 2026.**
+- Program is **active** with annual rounds.
 - ➡️ [CRC-P details](https://business.gov.au/grants-and-programs/cooperative-research-centres-projects-crcp-grants)
+
+### Cooperative Research Centres (CRC) Program — Round 27
+
+- Industry-research consortia grants, typically **$2–5 million** over 3–10 years.
+- Supports large-scale collaborative research partnerships between industry and research organisations.
+- General research collaboration (not AI-specific) but AI components are eligible.
+- **Closing 21 April 2026.**
+- ➡️ [CRC Program details](https://business.gov.au/grants-and-programs/cooperative-research-centres-crc-grants)
+
+### AI Accelerator CRC (Future)
+
+- Approximately **$50 million** planned for a dedicated AI Cooperative Research Centre.
+- Part of the broader AI Accelerator initiative to drive industry-led AI research at scale.
+- CRC Round 28 expected to open in **2027**.
+- ➡️ [AI Accelerator initiative](https://www.industry.gov.au/news/ai-accelerator-initiative-kicks-funding-industry-led-research)
 
 ---
 
@@ -198,7 +216,7 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 
 | Program / Initiative | Type | Value | Key Focus | Status |
 |----------------------|------|-------|-----------|--------|
-| AI Adopt Program | Federal Grant | $3–5m | SME AI adoption | Closed |
+| AI Adopt Program | Federal Grant | $3–5m | SME AI adoption | Centres operational |
 | AI & Digital Capability Centres | Federal Grant | $44m (total) | SME training, commercialisation | Concluded |
 | Catalysing AI in Regions | Federal Grant | $250k–$500k | Regional AI solutions | Concluded |
 | R&D Tax Incentive | Tax Offset | 38.5–43.5% | AI R&D projects | Active |
@@ -211,7 +229,9 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 | MRFF AI in Health | Federal Grant | $30m | Healthcare AI transformation | Active |
 | CSIRO Next Gen Graduates | Federal Program | Varies | AI workforce development | Active |
 | CSIRO-NSF AI Collaboration | International Grant | $9.6m (2023) | Responsible AI research | Active |
-| CRC-P AI Projects | Federal Grant | $100k–$3m | Collaborative AI research | Active |
+| CRC-P Round 19 (AI Stream) | Federal Grant | $100k–$3m ($20m pool) | Collaborative AI research | Closing 12 May 2026 |
+| CRC Program Round 27 | Federal Grant | $2–5m | Industry-research consortia | Closing 21 April 2026 |
+| AI Accelerator CRC | Federal (Future) | ~$50m | Dedicated AI CRC | Expected 2027 |
 | AWS AI Accelerator | Corporate | US$230m pool | Generative AI startups | Active |
 | NRFC | Co‑investment fund | $550m+ | Large-scale ventures | Active |
 | Fearless Innovator Grant | Micro‑grant | $100k | Female founders in AI | Completed (2024) |

--- a/docs/safety-standards/ai-australian-legislation.md
+++ b/docs/safety-standards/ai-australian-legislation.md
@@ -5,7 +5,7 @@ description: "Comprehensive overview of current legislation applicable to AI ado
 keywords: "AI legislation Australia, Australian AI law, AI privacy law, AI consumer law, AI discrimination law, AI intellectual property, AI legal compliance, Australian AI regulations, AI legal framework"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-01-31"
+last-reviewed: "2026-04-15"
 review-cycle: "quarterly"
 og_title: "Current Legal Landscape for AI in Australia"
 og_description: "Comprehensive overview of current legislation applicable to AI adoption in Australian business"
@@ -27,7 +27,7 @@ While Australia doesn't yet have AI-specific legislation, AI use is already gove
 In 2024 the Government released proposals for mandatory guardrails for high-risk AI applications alongside a Voluntary AI Safety Standard. In October 2025 the National AI Centre (NAIC) published updated **Guidance for AI Adoption**, which sets out six essential practices (AI6) and is now the primary government guidance for responsible AI governance and adoption. In December 2025 the **National AI Plan** confirmed that, for now, Australia will rely on **existing laws and sector regulators, supported by voluntary guidance and a new AI Safety Institute**, rather than introducing a standalone AI Act or immediate mandatory guardrails.
 
 !!! note "Policy is evolving"
-    The Australian AI policy landscape is changing rapidly. The information below reflects the position as of January 2026. Monitor [industry.gov.au/ai](https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence) and the AI Safety Institute for updates.
+    The Australian AI policy landscape is changing rapidly. The information below reflects the position as of April 2026. For government policy, guidance and institutional developments, see [Australian Government AI Policy and Frameworks](ai-government-policy-frameworks.md). Monitor [industry.gov.au/ai](https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence) and the AI Safety Institute for updates.
 
 !!! info "Why This Matters"
     Understanding the current legal landscape helps organisations:
@@ -59,6 +59,14 @@ The **Privacy Act 1988** is the principal legislation that regulates how persona
     - ✅ Ensure AI vendors are APP-compliant
     - ✅ Implement data minimisation practices
 
+**Automated decision-making transparency (effective 10 December 2026):** The Privacy and Other Legislation Amendment Act 2024 introduces new APP 1.7, 1.8 and 1.9 obligations. From 10 December 2026, APP entities must disclose in their privacy policies:
+
+- The types of personal information used in substantially automated decisions
+- The nature of decisions made solely or significantly by computer programs
+- Where those decisions could reasonably be expected to significantly affect individual rights or interests
+
+The OAIC is progressively publishing guidance on these new obligations throughout 2026. Organisations using AI in automated decision-making should begin privacy policy reviews now.
+
 **Penalties:** Since 2022 reforms, serious or repeated breaches can attract penalties of up to the greater of $50 million, three times the benefit obtained, or 30% of adjusted turnover ([oaic.gov.au](https://www.oaic.gov.au/privacy/privacy-legislation/the-privacy-act)).
 
 ---
@@ -80,7 +88,7 @@ The **Australian Consumer Law (ACL)** is a national law embedded in the Competit
     - ✅ Monitor AI output quality and accuracy
     - ✅ Keep records of AI decision logic for accountability
 
-**Regulatory context:** The ACCC is actively monitoring emerging AI-enabled practices, including reviews, claims and pricing models.
+**Regulatory context:** The ACCC is actively monitoring emerging AI-enabled practices, including reviews, claims and pricing models. In February 2026 the ACCC published its own AI transparency statement disclosing how it uses AI internally, and has flagged **"AI-washing"** (misleading claims about AI capabilities) as an enforcement concern. The Treasury's review of AI and the Australian Consumer Law found the existing framework "fit for purpose", making dedicated AI consumer legislation unlikely in the near term.
 
 ---
 
@@ -97,7 +105,7 @@ Australia maintains a federal anti‑discrimination framework, including acts li
 
 !!! warning "Actions Required"
     - ✅ Regularly audit AI systems for bias and discriminatory outcomes
-    - ✅ Document actions taken to ensure fairness
+    - ✅ Document actions taken to support fairness
     - ✅ Maintain human oversight for high-impact AI decisions
     - ✅ Be prepared to explain or justify AI outputs
 
@@ -122,7 +130,7 @@ Australia's **IP laws**—covering copyright, patents, trademarks and design rig
     - ✅ Avoid relying solely on AI-generated content for IP claims
     - ✅ Respect third-party IP and licensing terms
 
-**Reform note:** Government is considering text and data mining exemptions to clarify how AI can safely use IP-protected content.
+**Copyright reform (April 2026):** Parliament passed copyright reforms on 1 April 2026 establishing Australia's first orphan works scheme. Importantly, the Government **rejected a text-and-data-mining (TDM) exemption** for AI training — a proposal supported by technology firms — and is instead exploring a paid licensing model. This means organisations training AI models on copyrighted content in Australia must continue to rely on existing copyright exceptions or obtain licences from rights holders.
 
 ---
 
@@ -136,43 +144,19 @@ Australia's **IP laws**—covering copyright, patents, trademarks and design rig
 
 ---
 
-## Emerging Reforms (2025–2027 to watch)
+## Upcoming Legislative Reforms
 
-- 📊 **Guidance for AI Adoption (AI6) – in effect from October 2025**
-  NAIC's Guidance for AI Adoption sets out 6 essential practices for responsible AI governance and adoption, with two versions (Foundations and Implementation practices) and supporting tools (AI screening tool, AI policy guide and template, AI register template). It updates and replaces the Voluntary AI Safety Standard as the primary government reference point for organisations using AI in Australia.
+- 🔒 **Privacy Act — automated decision-making transparency (10 December 2026)**
+  New APP 1.7–1.9 obligations require disclosure when computer programs use personal information to make decisions significantly affecting individuals. See the Privacy Act section above for details. The OAIC is publishing guidance progressively throughout 2026.
 
-- 📋 **Voluntary AI Safety Standard (VAISS) – 10 guardrails now integrated into AI6**
-  The Voluntary AI Safety Standard, released in 2024, introduced 10 guardrails for safe and responsible AI. These guardrails remain relevant as a detailed control set and have been fully integrated into the Guidance for AI Adoption through an official "VAISS × implementation practices" crosswalk.
+- 📝 **Copyright reform — TDM exemption rejected (April 2026)**
+  Parliament rejected a text-and-data-mining exemption for AI training and is exploring a paid licensing model instead. See the IP section above for details. Further consultations on AI's impact on the creative sector are expected through the next National Cultural Policy process.
 
-- 🏛️ **National AI Plan and AI Safety Institute (announced November 2025)**
-  The National AI Plan (December 2025) sets a national roadmap to capture AI opportunities, spread benefits across the economy and keep Australians safe. The Government has paused work on standalone AI-specific legislation and mandatory guardrails, instead relying on existing "technology-neutral" laws and regulators, supported by a new **AI Safety Institute** (announced November 2025, rolling out from early 2026) to monitor, test and advise on emerging AI risks.
+- ⚖️ **Consumer law — no standalone AI legislation**
+  The Treasury review found the Australian Consumer Law "fit for purpose" for AI. No dedicated AI consumer legislation is expected in the near term. The ACCC continues to monitor AI-washing and misleading AI claims.
 
-- 🔒 **Privacy Act reforms**
-  Privacy reforms remain on the agenda, including stronger consent rules, potential rights to explanation for high-impact automated decisions, direct rights of action and higher penalties. These reforms will significantly shape compliant AI data practices.
-
-- 📝 **Copyright and IP reforms**
-  Ongoing work is examining text and data-mining exceptions, the legality of using copyrighted works to train AI models and how copyright applies to AI-generated content. These reforms are particularly important for organisations heavily relying on generative AI.
-
----
-
-## Government guidance for safe AI (AI6 and the Voluntary AI Safety Standard)
-
-In 2024 the Australian Government released the **Voluntary AI Safety Standard (VAISS)** as an interim framework consisting of 10 guardrails for safe and responsible AI development and deployment across all sectors.
-
-In October 2025 the National AI Centre released updated **Guidance for AI Adoption**, which:
-
-- condenses the 10 VAISS guardrails into **6 essential practices (AI6)**
-- expands guidance to cover both AI **deployers and developers**
-- provides more detailed, actionable implementation guidance and supporting tools.
-
-The Guidance for AI Adoption is now the **primary source of voluntary governance guidance** for Australian organisations. The 10 guardrails remain fully integrated into AI6 and are useful as a **detailed control catalogue**, especially when building AI policies, risk registers and vendor due-diligence processes.
-
-!!! success "How to Use This Guidance"
-    Organisations developing or deploying AI systems should:
-
-    - 📊 **Adopt AI6** as their top-level framework for responsible AI governance
-    - 📋 **Use the 10 guardrails** where more granular control statements are helpful or where external documents still refer to VAISS
-    - 🔗 **Link to existing obligations** in privacy, consumer law, safety, IP and cyber security
+!!! info "Government Policy and Guidance"
+    For coverage of the National AI Plan, AI Safety Institute, DTA mandatory requirements, Senate Committee response and other government policy developments, see [Australian Government AI Policy and Frameworks](ai-government-policy-frameworks.md).
 
 ---
 

--- a/docs/safety-standards/ai-government-policy-frameworks.md
+++ b/docs/safety-standards/ai-government-policy-frameworks.md
@@ -1,0 +1,184 @@
+---
+icon: lucide/landmark
+title: "Australian Government AI Policy and Frameworks"
+description: "Overview of Australian Government AI policy, guidance and institutional developments including the National AI Plan, AI Safety Institute, DTA mandatory requirements, AI6 and VAISS."
+keywords: "Australian AI policy, National AI Plan, AI Safety Institute, DTA AI policy, AI6 guidance, VAISS, AI governance Australia, mandatory AI requirements, Senate AI Committee"
+author: "SafeAI-Aus"
+robots: "index, follow"
+last-reviewed: "2026-04-15"
+review-cycle: "quarterly"
+og_title: "Australian Government AI Policy and Frameworks"
+og_description: "Overview of Australian Government AI policy, guidance and institutional developments"
+og_type: "article"
+og_url: "https://safeaiaus.org/safety-standards/ai-government-policy-frameworks/"
+og_image: "assets/safeaiaus-logo-600px.png"
+twitter_card: "summary_large_image"
+twitter_title: "Australian Government AI Policy and Frameworks"
+twitter_description: "Overview of Australian Government AI policy, guidance and institutional developments"
+---
+
+# Australian Government AI Policy and Frameworks
+
+> **Purpose:** Understand the Australian Government's approach to AI governance — policy, guidance, institutions and timelines
+> **Audience:** Governance, compliance, risk and strategy teams | **Time:** 30-40 minutes
+
+Australia does not yet have a standalone AI Act. Instead, the Government relies on **existing technology-neutral laws** (see [Current Legal Landscape](ai-australian-legislation.md)) supported by voluntary guidance, a growing set of institutional arrangements and — for Commonwealth agencies — the first mandatory AI requirements.
+
+This page covers government policy, guidance frameworks and institutional developments. For the laws themselves, see [Current Legal Landscape for AI in Australia](ai-australian-legislation.md).
+
+!!! note "Policy is evolving"
+    The Australian AI policy landscape is changing rapidly. The information below reflects the position as of April 2026. Monitor [industry.gov.au/ai](https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence) and the AI Safety Institute for updates.
+
+---
+
+## National AI Plan (December 2025)
+
+The **National AI Plan** sets Australia's national roadmap for AI. Key positions:
+
+- Australia will rely on **existing laws and sector regulators** rather than introducing a standalone AI Act or immediate mandatory guardrails
+- A new **AI Safety Institute** will monitor, test and advise on emerging AI risks
+- Government investment in AI infrastructure, skills and research through specific programs (AI Adopt Centres, AI Accelerator CRC, APS AI Plan)
+
+The Government's formal response to the **Senate Select Committee on Adopting AI** was tabled on 1 April 2026, confirming these positions and committing to:
+
+- Launch of the AI Accelerator CRC (CRC-P Round 19 now; CRC Round 28 in 2027)
+- Rejection of a text-and-data-mining exception in copyright law (see [legislation page](ai-australian-legislation.md))
+- Consultation on AI's impact on the creative sector through the next National Cultural Policy process
+- Affirmation of the Privacy Act automated decision-making reforms (effective 10 December 2026)
+
+---
+
+## AI Safety Institute
+
+The **Australian AI Safety Institute (AISI)** was formally established in early 2026 with **$29.9 million** in committed funding.
+
+**Remit:**
+
+- Technical assessments of advanced AI systems
+- Bilateral and multilateral engagement through the International Network of AI Safety Institutes
+- Publishing research on AI safety
+
+**Key developments:**
+
+- The AISI signed a Memorandum of Understanding with **Anthropic** on 1 April 2026 — the first formal industry collaboration under the National AI Plan. The MOU covers AI safety evaluation, infrastructure alignment and capability building. It is non-binding and does not confer preferential treatment in procurement
+- Australia and **Canada** agreed to strengthen bilateral cooperation on AI safety through the International Network of AI Safety Institutes
+
+The AISI advises; portfolio agencies and sector regulators retain enforcement responsibility.
+
+---
+
+## DTA Mandatory AI Requirements (Commonwealth Agencies)
+
+!!! warning "First mandatory deadline: 15 June 2026"
+    The Digital Transformation Agency's updated AI policy introduces the first mandatory AI requirements for Commonwealth agencies. This is the most significant shift from voluntary to mandatory obligations in Australian AI governance to date.
+
+The DTA updated its **Policy for the Responsible Use of AI in Government** (effective 15 December 2025). Key elements:
+
+- **Mandatory AI Impact Assessments** using a new [AI Impact Assessment Tool](https://www.digital.gov.au/ai/impact-assessment-tool/introduction) (12-section fillable template aligned with AI Ethics Principles)
+- **Mandatory AI procurement guidance**
+- **Mandatory foundational AI training** for all Australian Public Service staff
+- Requirement for agencies to appoint **Chief AI Officers**
+
+**Timeline:**
+
+| Date | Requirement |
+|------|-------------|
+| 15 December 2025 | Policy effective |
+| **15 June 2026** | **First mandatory requirements apply** |
+| December 2026 | All remaining requirements take effect |
+
+While these are mandatory only for Commonwealth agencies, they signal the direction for all Australian organisations. The DTA's AI Impact Assessment Tool is a practical resource for any organisation assessing AI risk.
+
+**GovAI Chat** — an AI assistant for APS staff — began trials from April 2026 as part of the broader APS AI Plan.
+
+---
+
+## Data Centre and AI Infrastructure Expectations (March 2026)
+
+The Department of Industry, Science and Resources published **voluntary-but-consequential expectations** for data centre and AI infrastructure developers on 23 March 2026.
+
+Key expectations:
+
+- Fair and well-paid Australian jobs
+- Investment in domestic workforce development
+- Contribution to research and innovation
+- Underwriting new renewable power supply
+
+Data centre proposals not closely aligned with these expectations will not be prioritised by Commonwealth regulatory assessments, giving the document practical regulatory weight.
+
+---
+
+## Guidance for AI Adoption (AI6)
+
+The **Guidance for AI Adoption** (October 2025) is the primary government guidance for responsible AI governance and adoption. Published by the National AI Centre (NAIC), it sets out **six essential practices**:
+
+1. Decide accountability
+2. Understand impacts
+3. Measure and manage risks
+4. Share information
+5. Test and monitor
+6. Maintain human control
+
+Two versions are available: **Foundations** (for organisations starting out) and **Implementation practices** (for more mature organisations). Supporting tools include an AI screening tool, AI policy guide and template, and AI register template.
+
+For detailed coverage, see [Guidance for AI Adoption (AI6)](guidance-for-ai-adoption-ai6.md).
+
+---
+
+## Voluntary AI Safety Standard (VAISS)
+
+The **Voluntary AI Safety Standard** (September 2024) introduced **10 guardrails** for safe and responsible AI. These guardrails remain relevant as a detailed control set and have been fully integrated into the Guidance for AI Adoption through an official "VAISS × implementation practices" crosswalk.
+
+!!! info "VAISS v2"
+    An expression of interest for VAISS v2 consultations has been published at consult.industry.gov.au. The open/closed status could not be confirmed as of April 2026 — verify directly at [consult.industry.gov.au](https://consult.industry.gov.au/voluntary-ai-safety-standard-v2-consultations-expression-of-interest).
+
+For detailed coverage of the 10 guardrails, see [Voluntary AI Safety Standard](voluntary-ai-safety-standard-10-guardrails.md).
+
+---
+
+## Government–Industry Arrangements
+
+| Arrangement | Date | Parties | Significance |
+|-------------|------|---------|--------------|
+| Anthropic MOU | 1 April 2026 | Australian Government, Anthropic | First National AI Plan industry arrangement. AI safety evaluation, infrastructure alignment, APS capability building. Non-binding |
+| Australia–Canada AI Safety Cooperation | 2026 | Australia, Canada | Bilateral AI safety cooperation through the International Network of AI Safety Institutes |
+
+---
+
+## ACCC Enforcement Approach
+
+The ACCC published its own AI transparency statement in February 2026 and has flagged **"AI-washing"** (misleading claims about AI capabilities) as an enforcement concern. The Treasury's review of AI and the Australian Consumer Law found the existing framework "fit for purpose", making dedicated AI consumer legislation unlikely in the near term.
+
+---
+
+## Key Dates
+
+| Date | Development |
+|------|-------------|
+| October 2025 | AI6 Guidance for AI Adoption published |
+| November 2025 | National AI Plan and AI Safety Institute announced |
+| 15 December 2025 | DTA AI Policy effective |
+| 23 March 2026 | Data centre expectations published |
+| 1 April 2026 | Senate Committee response tabled; Anthropic MOU signed; Copyright reform passed |
+| **15 June 2026** | **DTA first mandatory requirements** |
+| **10 December 2026** | **Privacy Act ADM obligations commence; DTA full compliance** |
+
+---
+
+### Key References
+
+- [National AI Plan](https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence) — industry.gov.au
+- [AI Safety Institute](https://www.industry.gov.au/news/australia-establish-new-institute-strengthen-ai-safety) — industry.gov.au
+- [DTA AI Policy Update](https://www.dta.gov.au/articles/ai-policy-update-strengthening-responsible-use-across-government) — dta.gov.au
+- [AI Impact Assessment Tool](https://www.digital.gov.au/ai/impact-assessment-tool/introduction) — digital.gov.au
+- [Government Response to Senate Select Committee on AI](https://www.industry.gov.au/publications/australian-government-response-senate-select-committee-adopting-artificial-intelligence-ai-report) — industry.gov.au
+- [Data Centre Expectations](https://www.industry.gov.au/publications/expectations-data-centres-and-ai-infrastructure-developers) — industry.gov.au
+- [Guidance for AI Adoption (AI6)](https://www.industry.gov.au/publications/guidance-for-ai-adoption) — industry.gov.au
+- [Voluntary AI Safety Standard](https://www.industry.gov.au/publications/voluntary-ai-safety-standard) — industry.gov.au
+
+---
+
+??? note "Disclaimer & Licence"
+    **Disclaimer:** This page provides general information about Australian Government AI policy and is not legal or professional advice. SafeAI-Aus has exercised care in preparation but does not guarantee accuracy, reliability or completeness. Policy positions and timelines are subject to change. Organisations should verify current status with the relevant government body.
+
+    **Licence:** Licensed under [Creative Commons Attribution 4.0 (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/). You are free to copy, adapt and redistribute with attribution: *"Source: SafeAI-Aus (safeaiaus.org)"*

--- a/docs/safety-standards/international-ai-legal-overview.md
+++ b/docs/safety-standards/international-ai-legal-overview.md
@@ -5,7 +5,7 @@ description: "Comprehensive overview of international AI regulations and legal f
 keywords: "international AI law, EU AI Act, US AI regulation, global AI compliance, AI legal landscape, Australian businesses abroad, AI regulation 2026"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-01-31"
+last-reviewed: "2026-04-15"
 review-cycle: "quarterly"
 og_title: "International AI Legal Landscape (2026) — What Australian Businesses Should Know"
 og_description: "Comprehensive overview of international AI regulations and legal frameworks for Australian businesses"
@@ -22,21 +22,21 @@ twitter_description: "Comprehensive overview of international AI regulations and
 > **Purpose:** Navigate international AI regulations affecting Australian organisations operating globally
 > **Audience:** Legal, compliance, international business and governance teams | **Time:** 60-90 minutes
 
-*Last updated: January 2026. This page is informational and not legal advice.*
+*Last updated: April 2026. This page is informational and not legal advice.*
 
 !!! note "Rapidly evolving landscape"
-    International AI regulations are changing fast. South Korea's AI Basic Act takes effect in January 2026 with implementing rules still emerging. Canada's AIDA died on the Order Paper and any replacement may differ substantially. Always verify current status with official sources before making compliance decisions.
+    International AI regulations are changing fast. The EU's Digital Omnibus may extend key AI Act deadlines but is not yet finalised. South Korea's AI Basic Act took effect in January 2026 with implementing rules still emerging. Canada's AIDA died on the Order Paper and any replacement may differ substantially. Always verify current status with official sources before making compliance decisions.
 
 As AI regulation accelerates globally, many jurisdictions already impose binding requirements or have near-term obligations that will affect Australian organisations exporting, operating, or handling data linked to those regions.
 
-Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Singapore, plus the global frameworks most often referenced by regulators.
+Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Singapore and recent bilateral agreements, plus the global frameworks most often referenced by regulators.
 
 ---
 
 ## Executive Snapshot
 
 !!! info "Key Jurisdictions at a Glance"
-    - 🇪🇺 **EU** — The **EU AI Act** is in force with staged obligations. Bans on "unacceptable risk" uses started **2 Feb 2025**; **general-purpose AI (GPAI)** duties start **2 Aug 2025**; most remaining rules phase in through **2026–2027**. Expect documentation, transparency, risk management and post-market monitoring obligations if you sell into the EU or provide GPAI there.
+    - 🇪🇺 **EU** — The **EU AI Act** is in force with staged obligations. Bans on "unacceptable risk" uses started **2 Feb 2025**; **general-purpose AI (GPAI)** duties started **2 Aug 2025**; the bulk compliance date for high-risk AI (Annex III), transparency and enforcement is **2 Aug 2026** (~16 weeks away). The **EU Digital Omnibus** proposes extending several deadlines (high-risk standalone to Dec 2027, products to Aug 2028) but has not yet been finalised.
 
     - 🇺🇸 **US** — No single federal AI law. Federal direction runs through **NIST AI RMF 1.0** and public-sector guidance (**OMB M-24-10**). States are moving: **Colorado's AI Act** (effective **30 June 2026**) requires risk programs, impact assessments and notices for "high-risk" AI. NYC mandates bias audits for automated hiring tools.
 
@@ -63,15 +63,19 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 
 ### European Union (EU)
 
-**Status & scope:** The **EU AI Act (Regulation (EU) 2024/1689)** is live with a **risk-tiered** regime (prohibited, high, limited, minimal), dedicated **GPAI** obligations and strong enforcement (up to 7% global turnover). Key dates: **2 Feb 2025** (prohibitions), **2 Aug 2025** (GPAI, governance/penalties), **from Aug 2026–27** (most high-risk rules).
+**Status & scope:** The **EU AI Act (Regulation (EU) 2024/1689)** is live with a **risk-tiered** regime (prohibited, high, limited, minimal), dedicated **GPAI** obligations and strong enforcement (up to 7% global turnover). Key dates: **2 Feb 2025** (prohibitions), **2 Aug 2025** (GPAI, governance/penalties), **2 Aug 2026** (bulk compliance for high-risk AI systems under Annex III, transparency obligations under Article 50 and national/EU-level enforcement — approximately 16 weeks away).
+
+!!! note "EU Digital Omnibus — Proposed Timeline Extensions"
+    The **EU Digital Omnibus** proposes significant extensions to several AI Act deadlines. If finalised, the deadline for high-risk AI standalone systems would move from August 2026 to **December 2027**; high-risk AI embedded in products would extend to **August 2028**; and synthetic media watermarking obligations would apply from **November 2026**. The Council and Parliament agreed negotiating positions in March 2026, targeting final agreement by **28 April 2026**. These proposed extensions have not yet been finalised. Monitor [artificialintelligenceact.eu](https://artificialintelligenceact.eu/) for the latest implementation timeline (accessed 15 April 2026).
 
 !!! warning "What to Do"
     - ✅ Map any **EU-facing** AI systems to risk categories; identify if you're a **provider**, **deployer**, **importer** or **distributor**
     - ✅ For **GPAI/models**, prepare **training-data summaries**, technical documentation and risk-mitigation processes (red-teaming, incident reporting)
+    - ✅ Do not rely on proposed Digital Omnibus extensions until formally adopted — plan for the **2 August 2026** compliance date as the baseline
 
 ### United States (US)
 
-**Status & scope:** No omnibus federal AI law. Federal levers include **NIST AI RMF 1.0** (widely adopted) and **OMB M-24-10** (governance for US federal agencies). States and cities are active: **Colorado SB24-205** (effective **30 June 2026**, delayed from the original February 2026 date via SB 25B-004) mandates **risk management programs, impact assessments, consumer notices and appeal/human review** for "high-risk" AI; **NYC Local Law 144** requires **bias audits and notices** for automated hiring tools.
+**Status & scope:** No omnibus federal AI law. Federal levers include **NIST AI RMF 1.0** (widely adopted) and **OMB M-24-10** (governance for US federal agencies). In April 2026, NIST published a **concept note on Trustworthy AI in Critical Infrastructure**, signalling a new AI RMF Profile for critical infrastructure sectors; no draft has been published yet ([nist.gov](https://www.nist.gov/), accessed 15 April 2026). States and cities are active: **Colorado SB24-205** (effective **30 June 2026**, delayed from the original February 2026 date via SB 25B-004) mandates **risk management programs, impact assessments, consumer notices and appeal/human review** for "high-risk" AI; **NYC Local Law 144** requires **bias audits and notices** for automated hiring tools.
 
 !!! warning "What to Do"
     - ✅ Align your program to **NIST AI RMF** (often accepted as a **defence/interoperability** baseline, including in Colorado's framework)
@@ -116,19 +120,27 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
     - ✅ Use **AI Verify** (or equivalent) for **bias, robustness, transparency** testing
     - ✅ Publish **assurance artefacts** for enterprise buyers
 
+### Bilateral: Australia–Canada AI Safety Cooperation
+
+**Status & scope:** In early 2026, Australia and Canada signed an **AI Safety Cooperation Agreement** to strengthen bilateral cooperation on AI safety through the **International Network of AI Safety Institutes**. The agreement covers joint research, information sharing and coordinated approaches to evaluating advanced AI systems ([industry.gov.au](https://www.industry.gov.au/), accessed 15 April 2026).
+
+!!! warning "What to Do"
+    - ✅ Monitor outcomes from the International Network of AI Safety Institutes — shared evaluation frameworks and safety benchmarks may influence future Australian regulatory expectations
+
 ---
 
 ## Side-by-Side Summary
 
-| Jurisdiction | Legal posture (Jan 2026) | Primary instruments | Key dates | Headline obligations (examples) |
+| Jurisdiction | Legal posture (Apr 2026) | Primary instruments | Key dates | Headline obligations (examples) |
 |---|---|---|---|---|
-| **EU** | Binding, phased | EU AI Act | Feb 2025 (bans); Aug 2025 (GPAI); **Aug 2026** (full enforcement); Aug 2027 (legacy GPAI) | Risk-tiered duties, GPAI transparency/docs, post-market monitoring, penalties up to 7% turnover |
+| **EU** | Binding, phased | EU AI Act; EU Digital Omnibus (proposed) | Feb 2025 (bans); Aug 2025 (GPAI); **Aug 2026** (high-risk/transparency/enforcement); proposed extensions to Dec 2027–Aug 2028 | Risk-tiered duties, GPAI transparency/docs, post-market monitoring, penalties up to 7% turnover |
 | **US** | Patchwork + federal guidance | NIST AI RMF; OMB M-24-10; **Colorado AI Act**; NYC AEDT law | **CO:** 30 June 2026; **NYC AEDT:** in force | Risk programs, **impact assessments**, notices, bias audits (hiring), consumer appeal/human review |
 | **Canada** | Dead (died Jan 2025) | **AIDA (Bill C-27)** – terminated | No timeline; re-introduction uncertain | Bill C-27 died on Order Paper; any future legislation may differ substantially from original AIDA proposal |
 | **UK** | Regulator-led framework | Gov't Response (Feb 2024); **AI Security Institute**; Data (Use and Access) Act | Data Act mid-2025; AI legislation expected 2025–26 | Sector regulators issue guidance; evaluation & assurance focus (frontier/GPAI); data/algorithmic accountability |
 | **Japan** | Soft-law + promotion act | **AI Guidelines for Business**; **AI Promotion Act** | Act effective **4 June 2025**; AI Strategy HQ operational Sept 2025 | Lifecycle governance guidance; R&D promotion; voluntary compliance (no direct penalties) |
 | **Korea** | Binding (framework) | **AI Basic Act** | **Effective 22 Jan 2026** | National governance; trust/safety foundations; fines up to KRW 30M; further rules expected |
 | **Singapore** | Voluntary but influential | **Model AI Governance (GenAI)**; **AI Verify** | Framework updated 2024–25; OECD/GPAI alignment 2025 | Testing toolkit + governance guidance; NIST RMF cross-walk; red-teaming benchmarks |
+| **AU–CA** | Bilateral cooperation | **AI Safety Cooperation Agreement** | Signed early 2026 | Joint research and evaluation via International Network of AI Safety Institutes |
 
 ---
 
@@ -164,6 +176,7 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 - [OMB M-24-10 - AI Governance (White House)](https://www.whitehouse.gov/omb/management/ofcio/advancing-governance-innovation-and-risk-management-for-agency-use-of-artificial-intelligence/)
 - [Colorado SB24-205 (Colorado General Assembly)](https://leg.colorado.gov/bills/sb24-205)
 - [NYC Local Law 144 - AEDT (NYC DCWP)](https://www.nyc.gov/site/dca/about/automated-employment-decision-tools.page)
+- [NIST Concept Note — Trustworthy AI in Critical Infrastructure (Apr 2026)](https://www.nist.gov/itl/ai-risk-management-framework)
 
 **Canada**
 
@@ -191,6 +204,10 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 
 - [Model AI Governance Framework for GenAI (IMDA)](https://www.imda.gov.sg/resources/press-releases-factsheets-and-speeches/press-releases/2024/public-consult-model-ai-governance-framework-genai)
 - [AI Verify Foundation](https://aiverifyfoundation.sg/)
+
+**Australia–Canada Bilateral**
+
+- [Australia–Canada AI Safety Cooperation Agreement (industry.gov.au)](https://www.industry.gov.au/)
 
 **Global Standards**
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -34,6 +34,7 @@ nav = [
     { "Overview" = "safety-standards/index.md" },
     { "Australian Standards" = [
       { "Relevant Australian Legislation" = "safety-standards/ai-australian-legislation.md" },
+      { "Government AI Policy & Frameworks" = "safety-standards/ai-government-policy-frameworks.md" },
       { "Voluntary AI Safety Standard (10 Guardrails)" = "safety-standards/voluntary-ai-safety-standard-10-guardrails.md" },
       { "Guidance for AI Adoption (AI6)" = "safety-standards/guidance-for-ai-adoption-ai6.md" },
     ]},


### PR DESCRIPTION
## Summary

Content updates from the April 2026 researcher digests. All actionable items from both weekly digests (10 Apr and 12 Apr) have been addressed.

### What changed in the regulatory landscape

- **DTA mandatory AI requirements** — first mandatory deadline for Commonwealth agencies is **15 June 2026**. New AI Impact Assessment Tool and Procurement Guidance published
- **Copyright reform** — Parliament rejected a text-and-data-mining exemption for AI training (1 Apr 2026). Exploring a paid licensing model instead
- **AI Safety Institute** — now formally operational with $29.9M funding. Signed first industry MOU with Anthropic
- **Senate Committee response** — Government tabled its response to the Senate Select Committee on AI (1 Apr 2026), confirming the voluntary-first approach
- **Privacy Act ADM obligations** — new automated decision-making transparency requirements take effect 10 December 2026
- **EU AI Act** — bulk compliance date 2 August 2026 (~16 weeks). Digital Omnibus proposes extending high-risk deadlines but not yet finalised
- **Grants** — CRC Program Round 27 closes 21 April 2026. CRC-P Round 19 has a $20M AI stream closing 12 May 2026

### Pages updated

| Page | Changes |
|------|---------|
| `ai-grants-funding-australia.md` | CRC Round 27, CRC-P Round 19 AI stream, AI Accelerator CRC, ARC Linkage closed, AI Adopt Centres operational, deadline callout |
| `ai-aus-tools-frameworks.md` | DTA AI Impact Assessment Tool, Procurement Guidance, GovAI Chat |
| `ai-australian-legislation.md` | Privacy Act ADM obligations (Dec 2026), copyright reform (TDM rejected), ACCC AI-washing. Slimmed down — policy content moved to new page |
| `ai-government-policy-frameworks.md` | **New page** — National AI Plan, AI Safety Institute, DTA mandatory requirements, Senate Committee response, Anthropic MOU, data centre expectations, AI6/VAISS, key dates |
| `international-ai-legal-overview.md` | EU AI Act 2 Aug 2026 compliance date, Digital Omnibus proposed extensions, NIST Critical Infrastructure concept note, Australia-Canada cooperation |
| `zensical.toml` | Nav entry for new Government AI Policy & Frameworks page |

### Content hardening

All pages passed the content hardening skill (defensibility, sourcing, style, engagement). One edit: "ensure fairness" → "support fairness".

### Deferred items (by design)

- OAIC ADM guidance — not yet published, templates will be updated when it is
- VAISS v2 EOI status — needs manual check at consult.industry.gov.au
- Governance templates privacy policy update — waiting on OAIC guidance

## Test plan

- [ ] Site builds without errors
- [ ] New Government AI Policy & Frameworks page renders and appears in nav
- [ ] Cross-references between legislation and policy pages work both ways
- [ ] Grants page deadline callout is prominent
- [ ] All external URLs are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)