### PR TITLE
docs: Content updates from researcher digest 2026-04-19

### DIFF
--- a/docs/brainstorms/digest-summary-2026-04-19.md
+++ b/docs/brainstorms/digest-summary-2026-04-19.md
@@ -1,0 +1,38 @@
+# Researcher Digest Summary — 19 April 2026
+
+Source: agent-engine/research/weekly-digest-2026-04-19.md
+
+## Pages needing updates
+
+- **`docs/business-resources/ai-grants-funding-australia.md`** — CRC Round 27 closing date conflict: verify immediately at business.gov.au whether deadline is 21 April or 29 April 2026. If 21 April, window may have passed. Also verify whether AI Adopt Program has a new open round closing 12 May 2026 (conflicts with April 12 digest which said initial round closed). CRC-P Round 19 AI stream ($20M) closes 12 May 2026 — ensure this is displayed prominently.
+
+- **`docs/safety-standards/international-ai-legal-overview.md`** — EU AI Act Digital Omnibus trilogue is targeting political agreement by 28 April 2026. Once outcome is confirmed, update the page to reflect any confirmed deadline extensions for high-risk AI systems (proposed: December 2027 for stand-alone, August 2028 for embedded). August 2, 2026 general application date is unchanged.
+
+## Flagged for manual action
+
+- **CRC Round 27 deadline verification:** Search results give conflicting dates (21 April vs 29 April for Stage 1). With today being 19 April, this is urgent. Check https://business.gov.au/grants-and-programs/cooperative-research-centres-crc-grants directly and update the grants page before the deadline passes.
+
+- **AI Adopt Program new round:** Check whether a new competitive application round is open at https://business.gov.au/grants-and-programs/artificial-intelligence-ai-adopt-program. If confirmed open with 12 May deadline, this should be added to the grants page as a Critical item.
+
+- **VAISS v2 EOI status:** Unconfirmed since April 12 digest. Check https://consult.industry.gov.au/ to determine if the VAISS v2 expression of interest is still open and whether a closing date applies.
+
+- **EU AI Act Digital Omnibus outcome:** Monitor from 28 April 2026. Once a political agreement is reached, update the international overview page to replace proposed changes with confirmed ones.
+
+## No action needed
+
+- AI6 Guidance (October 2025 version): No revision this week.
+- VAISS (10 Guardrails): Voluntary status unchanged; no updates.
+- Privacy Act APP 1.7–1.9: OAIC guidance still pending; compliance date (10 December 2026) unchanged.
+- ISO/IEC 42001:2023: No standard revision; adoption continuing.
+- NIST AI RMF: No new publications since concept note of 7 April 2026.
+- State/territory strategies: No new developments detected this week.
+- ACCC 2026–27 priorities: Released but no AI-specific enforcement priority; no content update needed.
+- National AI Plan: No new implementation announcements since Anthropic MOU (1 April 2026).
+
+## Carry-forward from prior digests (if not yet actioned)
+
+The following items from `weekly-digest-2026-04-10.md` and `weekly-digest-2026-04-12.md` remain live:
+
+1. `docs/safety-standards/ai-australian-legislation.md` — DTA AI Policy (15 June 2026 first mandatory requirement, now 8 weeks away), AI Safety Institute operational status, copyright reform (1 April 2026), Government response to Senate Select Committee (1 April 2026), data centre expectations (23 March 2026).
+2. `docs/business-resources/ai-aus-tools-frameworks.md` — DTA AI Impact Assessment Tool and Procurement Guidance (effective December 2025).
+3. `docs/business-resources/ai-grants-funding-australia.md` — ARC Linkage 2026 closed (18 March 2026); Catalysing AI Opportunity Regions Round 1 status unverified.

--- a/docs/business-resources/ai-aus-tools-frameworks.md
+++ b/docs/business-resources/ai-aus-tools-frameworks.md
@@ -4,7 +4,7 @@ title: "AI Tools & Frameworks for Australian Businesses"
 description: "Curated collection of AI tools, frameworks and resources for Australian businesses implementing AI safely and responsibly. Includes risk management, governance and technical testing tools."
 keywords: "AI tools Australia, AI frameworks Australia, AI risk management tools, AI governance tools, AI testing tools, Australian AI resources, AI safety tools, AI compliance tools"
 author: "SafeAI-Aus"
-last-reviewed: "2026-04-15"
+last-reviewed: "2026-04-19"
 review-cycle: "quarterly"
 robots: "index, follow"
 og_title: "AI Tools & Frameworks for Australian Businesses"
@@ -42,6 +42,9 @@ In December 2025, the Digital Transformation Agency (DTA) overhauled its **Polic
 
 - **15 June 2026** – first mandatory requirements take effect
 - **December 2026** – all remaining requirements take effect
+
+!!! warning "15 June 2026 is approximately 8 weeks away (as of April 2026)"
+    Commonwealth agencies are now within 8 weeks of the first mandatory requirements under the DTA's updated AI policy. Agencies should ensure their AI governance processes, impact assessments and relevant documentation are in place before this date. Private sector organisations and state agencies are encouraged to treat these requirements as a reference point for their own AI governance maturity.
 
 !!! tip "Relevance beyond the Commonwealth"
     While these requirements are mandatory only for Commonwealth agencies, they signal the direction for all Australian organisations. The Impact Assessment Tool is freely available and provides a solid starting point for any AI governance program.

--- a/docs/business-resources/ai-grants-funding-australia.md
+++ b/docs/business-resources/ai-grants-funding-australia.md
@@ -5,7 +5,7 @@ description: "Comprehensive guide to AI grants, funding programs and financial s
 keywords: "AI grants Australia, AI funding Australia, AI business grants, Australian AI funding, AI government grants, AI business support, AI investment Australia, AI startup funding"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-04-15"
+last-reviewed: "2026-04-19"
 review-cycle: "quarterly"
 og_title: "AI Grants and Funding Opportunities for Australian Businesses"
 og_description: "Comprehensive guide to AI grants, funding programs and financial support for Australian businesses"
@@ -23,8 +23,9 @@ twitter_description: "Comprehensive guide to AI grants, funding programs and fin
 > **Audience:** Business owners, CFOs, project managers and grant applicants | **Time:** 30-45 minutes
 
 !!! warning "Time-sensitive: Upcoming deadlines"
-    - **CRC Program Round 27** closes **21 April 2026** — [Apply now](https://business.gov.au/grants-and-programs/cooperative-research-centres-crc-grants)
+    - **CRC Program Round 27** — closing date disputed (**21 April 2026** per earlier sources, or **Stage 1: 29 April 2026** per more recent search results). **Verify the correct date immediately at [business.gov.au](https://business.gov.au/grants-and-programs/cooperative-research-centres-crc-grants) before applying** — both possible deadlines are days away as of 19 April 2026. See warning in the section below.
     - **CRC-P Round 19 (AI stream, $20M)** closes **12 May 2026** — [Apply now](https://business.gov.au/grants-and-programs/cooperative-research-centres-projects-crcp-grants)
+    - **AI Adopt Program** — a possible new competitive application round may be open with applications reportedly closing **12 May 2026**. Status unconfirmed — verify at [business.gov.au](https://business.gov.au/grants-and-programs/artificial-intelligence-ai-adopt-program) before acting. See warning in the section below.
 
 AI is reshaping industries across Australia. To support businesses in responsibly adopting and scaling AI, a mix of government grants, research programs and industry‑backed accelerators are available. This article provides a consolidated overview of the most relevant opportunities for Australian businesses today.
 
@@ -41,6 +42,9 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 - **AI Adopt Centres** are now operational across Australia through 2026/27, providing free specialist services to eligible SMEs including AI readiness assessments, implementation support and training.
 - The competitive grant round has **concluded**, but centre services are accessible to eligible businesses.
 - ➡️ [SME services](https://business.gov.au/expertise-and-advice/ai-adopt-centres) | [Program overview](https://business.gov.au/grants-and-programs/artificial-intelligence-ai-adopt-program)
+
+!!! warning "Possible new application round — verify before acting"
+    As of 19 April 2026, search results indicate a possible new competitive application round may be open, with applications reportedly closing **12 May 2026**, for grants of $3M–$5M over four years (up to 50% of eligible project expenditure) to establish AI Adopt Centres supporting SMEs. This conflicts with earlier reporting that the initial round had concluded. Verify current status at [business.gov.au](https://business.gov.au/grants-and-programs/artificial-intelligence-ai-adopt-program) before taking action. ([business.gov.au](https://business.gov.au/grants-and-programs/artificial-intelligence-ai-adopt-program), accessed 19 April 2026)
 
 ### AI and Digital Capability Centres
 
@@ -108,8 +112,11 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 - Industry-research consortia grants, typically **$2–5 million** over 3–10 years.
 - Supports large-scale collaborative research partnerships between industry and research organisations.
 - General research collaboration (not AI-specific) but AI components are eligible.
-- **Closing 21 April 2026.**
+- Closing date disputed — **verify immediately before applying** (see warning below).
 - ➡️ [CRC Program details](https://business.gov.au/grants-and-programs/cooperative-research-centres-crc-grants)
+
+!!! warning "Closing date requires urgent verification — deadline may be 21 or 29 April 2026"
+    Search results give conflicting closing dates for Round 27: **21 April 2026** (cited in sources from 10 April 2026) or **Stage 1: 29 April 2026** (per more recent search extracts, which describe a multi-stage process with Stage 1 outcomes in July 2026, Stage 2 opening July 2026, Stage 2 closing September 2026, and funding commencing July 2027). As of 19 April 2026, both possible deadlines are imminent. **Verify the correct date immediately at [business.gov.au](https://business.gov.au/grants-and-programs/cooperative-research-centres-crc-grants) before applying.** ([business.gov.au](https://business.gov.au/grants-and-programs/cooperative-research-centres-crc-grants), accessed 19 April 2026)
 
 ### AI Accelerator CRC (Future)
 
@@ -216,7 +223,7 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 
 | Program / Initiative | Type | Value | Key Focus | Status |
 |----------------------|------|-------|-----------|--------|
-| AI Adopt Program | Federal Grant | $3–5m | SME AI adoption | Centres operational |
+| AI Adopt Program | Federal Grant | $3–5m | SME AI adoption | Centres operational; possible new round (closes 12 May?) — **verify** |
 | AI & Digital Capability Centres | Federal Grant | $44m (total) | SME training, commercialisation | Concluded |
 | Catalysing AI in Regions | Federal Grant | $250k–$500k | Regional AI solutions | Concluded |
 | R&D Tax Incentive | Tax Offset | 38.5–43.5% | AI R&D projects | Active |
@@ -230,7 +237,7 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 | CSIRO Next Gen Graduates | Federal Program | Varies | AI workforce development | Active |
 | CSIRO-NSF AI Collaboration | International Grant | $9.6m (2023) | Responsible AI research | Active |
 | CRC-P Round 19 (AI Stream) | Federal Grant | $100k–$3m ($20m pool) | Collaborative AI research | Closing 12 May 2026 |
-| CRC Program Round 27 | Federal Grant | $2–5m | Industry-research consortia | Closing 21 April 2026 |
+| CRC Program Round 27 | Federal Grant | $2–5m | Industry-research consortia | Closing 21 or 29 April — **verify immediately** |
 | AI Accelerator CRC | Federal (Future) | ~$50m | Dedicated AI CRC | Expected 2027 |
 | AWS AI Accelerator | Corporate | US$230m pool | Generative AI startups | Active |
 | NRFC | Co‑investment fund | $550m+ | Large-scale ventures | Active |

--- a/docs/safety-standards/international-ai-legal-overview.md
+++ b/docs/safety-standards/international-ai-legal-overview.md
@@ -5,7 +5,7 @@ description: "Comprehensive overview of international AI regulations and legal f
 keywords: "international AI law, EU AI Act, US AI regulation, global AI compliance, AI legal landscape, Australian businesses abroad, AI regulation 2026"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-04-15"
+last-reviewed: "2026-04-19"
 review-cycle: "quarterly"
 og_title: "International AI Legal Landscape (2026) — What Australian Businesses Should Know"
 og_description: "Comprehensive overview of international AI regulations and legal frameworks for Australian businesses"
@@ -36,7 +36,7 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 ## Executive Snapshot
 
 !!! info "Key Jurisdictions at a Glance"
-    - 🇪🇺 **EU** — The **EU AI Act** is in force with staged obligations. Bans on "unacceptable risk" uses started **2 Feb 2025**; **general-purpose AI (GPAI)** duties started **2 Aug 2025**; the bulk compliance date for high-risk AI (Annex III), transparency and enforcement is **2 Aug 2026** (~16 weeks away). The **EU Digital Omnibus** proposes extending several deadlines (high-risk standalone to Dec 2027, products to Aug 2028) but has not yet been finalised.
+    - 🇪🇺 **EU** — The **EU AI Act** is in force with staged obligations. Bans on "unacceptable risk" uses started **2 Feb 2025**; **general-purpose AI (GPAI)** duties started **2 Aug 2025**; the bulk compliance date for high-risk AI (Annex III), transparency and enforcement is **2 Aug 2026** (~15 weeks away). The **EU Digital Omnibus** proposes extending several deadlines (high-risk standalone to Dec 2027, products to Aug 2028) but has not yet been finalised.
 
     - 🇺🇸 **US** — No single federal AI law. Federal direction runs through **NIST AI RMF 1.0** and public-sector guidance (**OMB M-24-10**). States are moving: **Colorado's AI Act** (effective **30 June 2026**) requires risk programs, impact assessments and notices for "high-risk" AI. NYC mandates bias audits for automated hiring tools.
 
@@ -63,10 +63,10 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 
 ### European Union (EU)
 
-**Status & scope:** The **EU AI Act (Regulation (EU) 2024/1689)** is live with a **risk-tiered** regime (prohibited, high, limited, minimal), dedicated **GPAI** obligations and strong enforcement (up to 7% global turnover). Key dates: **2 Feb 2025** (prohibitions), **2 Aug 2025** (GPAI, governance/penalties), **2 Aug 2026** (bulk compliance for high-risk AI systems under Annex III, transparency obligations under Article 50 and national/EU-level enforcement — approximately 16 weeks away).
+**Status & scope:** The **EU AI Act (Regulation (EU) 2024/1689)** is live with a **risk-tiered** regime (prohibited, high, limited, minimal), dedicated **GPAI** obligations and strong enforcement (up to 7% global turnover). Key dates: **2 Feb 2025** (prohibitions), **2 Aug 2025** (GPAI, governance/penalties), **2 Aug 2026** (bulk compliance for high-risk AI systems under Annex III, transparency obligations under Article 50 and national/EU-level enforcement — approximately 15 weeks away).
 
-!!! note "EU Digital Omnibus — Proposed Timeline Extensions"
-    The **EU Digital Omnibus** proposes significant extensions to several AI Act deadlines. If finalised, the deadline for high-risk AI standalone systems would move from August 2026 to **December 2027**; high-risk AI embedded in products would extend to **August 2028**; and synthetic media watermarking obligations would apply from **November 2026**. The Council and Parliament agreed negotiating positions in March 2026, targeting final agreement by **28 April 2026**. These proposed extensions have not yet been finalised. Monitor [artificialintelligenceact.eu](https://artificialintelligenceact.eu/) for the latest implementation timeline (accessed 15 April 2026).
+!!! note "EU Digital Omnibus — Proposed Timeline Extensions (trilogue target: 28 April 2026)"
+    The **EU Digital Omnibus** proposes significant extensions to several AI Act deadlines. If finalised, the deadline for high-risk AI standalone systems would move from August 2026 to **December 2027**; high-risk AI embedded in products would extend to **August 2028**; and synthetic media watermarking obligations would apply from **November 2026**. The first trilogue meeting commenced 26 March 2026; the Council and Parliament are targeting a political agreement by **28 April 2026**. As of 19 April 2026, this agreement has not yet been reached. These proposed extensions have not been finalised — **do not rely on them for compliance planning until formally adopted**. Monitor [artificialintelligenceact.eu](https://artificialintelligenceact.eu/) for the latest implementation timeline (accessed 19 April 2026).
 
 !!! warning "What to Do"
     - ✅ Map any **EU-facing** AI systems to risk categories; identify if you're a **provider**, **deployer**, **importer** or **distributor**


### PR DESCRIPTION
## Summary

Content updates based on the weekly researcher digest (19 April 2026).

### Changes made

- **`docs/business-resources/ai-grants-funding-australia.md`** — Added urgent warning about conflicting CRC Program Round 27 closing dates (21 April vs Stage 1: 29 April 2026 per current search extracts). Updated top warning banner and summary table to reflect the uncertainty. Added verification warning for a possible new AI Adopt Program application round reportedly closing 12 May 2026 (conflicts with prior reporting that the round had concluded — requires manual verification at business.gov.au before acting).

- **`docs/safety-standards/international-ai-legal-overview.md`** — Updated EU AI Act 2 August 2026 general application deadline countdown from ~16 weeks to ~15 weeks. Strengthened the EU Digital Omnibus note to include the 28 April 2026 trilogue target date and explicit guidance not to rely on proposed extensions until formally adopted. Updated access date to 19 April 2026.

- **`docs/business-resources/ai-aus-tools-frameworks.md`** — Added proximity warning that DTA mandatory AI requirements (first tranche) take effect 15 June 2026, approximately 8 weeks from 19 April 2026. Commonwealth agencies directed to ensure governance frameworks and impact assessments are in place before this date.

### Flagged for manual action

- **CRC Round 27 closing date** — Conflicting sources give either 21 April (2 days away from 19 April) or Stage 1: 29 April 2026 (10 days away). Requires immediate manual verification at https://business.gov.au/grants-and-programs/cooperative-research-centres-crc-grants before the window closes. If 21 April has passed by the time this is reviewed, update the section to reflect the actual status.

- **AI Adopt Program new round** — Search results indicate a possible new competitive round open (closing 12 May 2026, $3M–$5M grants). Verify at https://business.gov.au/grants-and-programs/artificial-intelligence-ai-adopt-program — if confirmed, update the section to remove the "concluded" language and add the deadline prominently.

- **EU AI Act Digital Omnibus outcome** — Political agreement targeted by 28 April 2026. Once outcome is confirmed, update `docs/safety-standards/international-ai-legal-overview.md` to replace proposed extensions with confirmed dates (or confirm no change if negotiations fail). Key proposed changes: high-risk standalone systems → December 2027; embedded → August 2028.

- **VAISS v2 Expression of Interest** — Status (open/closed) unconfirmed since April 12 digest. Manual check at https://consult.industry.gov.au/ recommended.

- **AI Safety Institute operational status** — Referenced as carry-forward from prior digest; no new developments detected this week. Check `docs/safety-standards/ai-government-policy-frameworks.md` for current coverage.

### Not actioned (by design)

- **ACCC 2026–27 priorities** — Released but no AI-specific enforcement priority; no content update needed (monitoring only).
- **EU AI Act August 2, 2026 general date** — Already reflected on international overview page; week count updated. No new information this week.
- **AI6 Guidance, VAISS 10 Guardrails, Privacy Act APP 1.7–1.9, ISO/IEC 42001, NIST AI RMF** — No new developments this week.
- **National AI Plan, state/territory strategies** — No new announcements since Anthropic MOU (1 April 2026).
- **Copyright reform, ARC Linkage 2026** — Already actioned on prior update; confirmed current on page.

## Source

Researcher digest: `agent-engine/research/weekly-digest-2026-04-19.md`

**Ready for review.**