### PR TITLE
fix: Weekly maintenance fixes 2026-04-20

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,14 +15,14 @@ This file is for AI coding and documentation agents working on this repository. 
 
 ## 2. Dev environment & setup
 
-- Requires Python **3.10+**.
+- Requires Python **3.12**. Use `.venv-py312` as the virtual environment directory (not `.venv`). CLAUDE.md is the authoritative source on the Python version; where AGENTS.md and CLAUDE.md conflict, CLAUDE.md takes precedence.
 - Dependencies are pinned in `requirements.txt`. Zensical is the primary dependency (Rust-based but installable via pip).
 
 ### Setup commands
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
+python3.12 -m venv .venv-py312
+source .venv-py312/bin/activate  # Windows: .venv-py312\Scripts\activate
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
Automated fixes from the weekly health check (2026-04-20).

## Fixes applied

- **AGENTS.md — Python version and venv name corrected**: Section 2 specified Python 3.10+ and `.venv`, directly contradicting CLAUDE.md's definitive requirement of Python 3.12 and `.venv-py312`. Updated setup commands and added an explicit precedence note ("where AGENTS.md and CLAUDE.md conflict, CLAUDE.md takes precedence"). This closes QA review suggestion #13 (2026-04-19) and prevents future agents from creating the wrong virtual environment.

## Issues reported (not auto-fixed)

- **[low] zensical 0.0.32 → 0.0.33 available** — One patch version behind. Likely minor bug fixes. Upgrade risk: low. Requires human approval before upgrading (per policy).
- **[info] "Strict mode is currently unsupported" build warning** — Emitted by zensical 0.0.32 when `--strict` is passed. Build still passes. May be resolved in 0.0.33. Not a blocking issue.
- **[info] GitHub Actions workflow run status** — No tool available to list workflow run history. CI health verified indirectly via successful local build and the absence of reported failures on open PRs.
- **[info] 2 open PRs pending review** — #76 (content-update/2026-04-19) and #77 (seo-fix/2026-04-19), both raised 2026-04-19. No action required from this agent.

Source: agent-engine/maintenance/health-report-2026-04-20.md