### PR TITLE
fix: Monthly SEO fixes 2026-05-12

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,10 @@ og_title: "SafeAI-Aus: Australia's AI Safety Resource"
 og_description: "Practical tools, open standards and trusted guidance for Australian businesses adopting AI safely"
 og_url: "https://safeaiaus.org/"
 og_image: "assets/safeaiaus-logo-600px.png"
+twitter_card: "summary_large_image"
 twitter_title: "SafeAI-Aus: Australia's AI Safety Resource"
 twitter_description: "Practical tools, open standards and trusted guidance for Australian businesses adopting AI safely"
+robots: "index, follow"
 hide:
   - navigation
   - toc

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -4,6 +4,25 @@ Allow: /
 # Security files
 Allow: /.well-known/security.txt
 
+# AI crawlers — explicitly allowed (content is CC BY 4.0, see /llms.txt for conditions)
+User-agent: GPTBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
 # Sitemap location
 Sitemap: https://safeaiaus.org/sitemap.xml
 


### PR DESCRIPTION
Automated fixes from the monthly SEO audit (12 May 2026).

## Fixes applied

### 1. Homepage frontmatter — missing `twitter_card` and `robots` fields (`docs/index.md`)
`index.md` was the only page missing two required frontmatter fields declared as mandatory in the SEO spec:
- Added `twitter_card: "summary_large_image"` — without this, X/Twitter previews fall back to a plain summary card instead of the large-image format used on every other page.
- Added `robots: "index, follow"` — without this, crawl intent for the homepage is undeclared.

### 2. AI crawler entries in `robots.txt`
The existing `User-agent: *  Allow: /` already permits all crawlers, but the SEO spec requires AI crawlers to be explicitly named. Added explicit `User-agent` blocks for:
- `GPTBot` (OpenAI)
- `Claude-Web` / `anthropic-ai` (Anthropic)
- `CCBot` (Common Crawl)
- `PerplexityBot`
- `Google-Extended` (Gemini training)

All are granted `Allow: /`. A comment points to `/llms.txt` for the CC BY 4.0 usage conditions.

## Issues reported (not auto-fixed — require human action)

### Content freshness — 2 pages overdue for review
| Page | Last reviewed | Days overdue |
|------|--------------|-------------|
| `docs/business-resources/ai-learning-development-directory.md` | 2026-01-31 | 101 days (threshold: 100) |
| `docs/resources/australian-ai-community.md` | 2026-01-31 | 101 days (threshold: 100) |

### Schema markup — missing `HowTo` on 2 governance templates
| Page | Has FAQ | Has HowTo |
|------|---------|-----------|
| `docs/governance-templates/ai-readiness-checklist.md` | ✓ | ✗ |
| `docs/governance-templates/ai-vendor-evaluation-checklist.md` | ✓ | ✗ |
Not auto-fixed — requires understanding page content to write a valid HowTo block.

### Sitemap — no `<lastmod>` dates
The generated `site/sitemap.xml` contains `<loc>` entries only; no `<lastmod>` tags. This is a Zensical build behaviour, not a content issue. Google uses `<lastmod>` for recrawl prioritisation. Requires either a Zensical feature/plugin or a post-build script to inject last-modified dates from git history.

### Technical SEO — pages built but excluded from sitemap
These five pages build successfully but are not in the nav and therefore not in `sitemap.xml`:
- `/about/`, `/contact/`, `/newsletter/`, `/LICENSE/`, `/NOTICE/`

`/about/` and `/contact/` have full SEO frontmatter and are linked from the footer. Consider adding them to the sitemap via a Zensical config option or explicit include list. `/LICENSE/` and `/NOTICE/` are legal pages — excluding them from the sitemap is appropriate.

### External link verification — inconclusive
Network requests from the build environment were blocked (all external URLs returned connection errors). External links could not be verified this cycle. Per the site-specific gotchas, `.gov.au` 403 responses are expected bot-protection, not broken links. Recommend running external link verification from a non-sandboxed environment.

---

Source: agent-engine/maintenance/seo-report-2026-05-12.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8F2fGQTSRfvaiyjhZwxqW)_