### PR TITLE
fix: Monthly SEO fixes 2026-05-13

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,10 @@ og_title: "SafeAI-Aus: Australia's AI Safety Resource"
 og_description: "Practical tools, open standards and trusted guidance for Australian businesses adopting AI safely"
 og_url: "https://safeaiaus.org/"
 og_image: "assets/safeaiaus-logo-600px.png"
+twitter_card: "summary_large_image"
 twitter_title: "SafeAI-Aus: Australia's AI Safety Resource"
 twitter_description: "Practical tools, open standards and trusted guidance for Australian businesses adopting AI safely"
+robots: "index, follow"
 hide:
   - navigation
   - toc

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -4,6 +4,28 @@ Allow: /
 # Security files
 Allow: /.well-known/security.txt
 
+# AI crawlers — explicitly allowed for indexing and training under CC BY 4.0
+User-agent: GPTBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: YouBot
+Allow: /
+
 # Sitemap location
 Sitemap: https://safeaiaus.org/sitemap.xml
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -54,6 +54,7 @@ Australian and international AI regulatory guidance:
 Practical adoption support:
 
 - **Safe AI Adoption Guide** - Where to start, what to avoid
+- **AI Governance FAQ** - Common questions on AI governance for Australian organisations
 - **AI Grants & Funding** - Australian government opportunities
 - **Tools & Frameworks** - Recommended AI tools
 - **State & Territory Resources** - Local government programs
@@ -100,4 +101,4 @@ Agents can poll `/updates.json` to discover what has changed since their last vi
 - GitHub: github.com/safeai-aus/safeai-aus.github.io
 
 ---
-Last updated: 2026-04-15
+Last updated: 2026-05-13

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@ license = "CC BY 4.0"
 repo = "https://github.com/safeai-aus/safeai-aus.github.io"
 website = "https://safeaiaus.org"
 policy-version = "1.2"
-last-updated = "2026-04-15"
+last-updated = "2026-05-13"
 changelog = "https://safeaiaus.org/updates.json"
 full-summary = "https://safeaiaus.org/llms-full.txt"
 


### PR DESCRIPTION
Automated fixes from the monthly SEO audit (13 May 2026).

## Fixes applied

- **docs/index.md** — Added `robots: "index, follow"` and `twitter_card: "summary_large_image"` to frontmatter. The Jinja2 template only emits the robots meta tag and Twitter card type when these fields are explicitly present; without them the homepage was silently missing both signals. This issue was also identified in the 3 May report (PR #81) but that PR was not merged into main.

- **docs/robots.txt** — Added explicit `User-agent` entries for GPTBot, Claude-Web, PerplexityBot, Google-Extended, CCBot, Applebot-Extended, and YouBot (all `Allow: /`). The wildcard rule already permitted all crawlers; this makes AI crawler access unambiguous, consistent with the `llms.txt` declaration that indexing and training are permitted under CC BY 4.0.

- **llms.txt** — Bumped `last-updated` from `2026-04-15` to `2026-05-13` to reflect content changes since April (AI Governance FAQ added, grants/tools updated, legislation and international pages updated).

- **llms-full.txt** — Added AI Governance FAQ to the Business Resources content inventory (it was omitted despite being a full published page added in April 2026). Updated "Last updated" footer date to 2026-05-13.

## Issues reported (not auto-fixed)

- **Sitemap: no `<lastmod>` dates** — Zensical does not generate lastmod. Search engines lack freshness signals. A post-build script injecting lastmod from git history would address this (flagged since April 2026).

- **about, contact, newsletter not in sitemap** — Built and served but absent from the auto-generated sitemap (not in nav). Add to nav or supplement sitemap if indexing is desired.

- **Schema: missing `howto` frontmatter** — `ai-readiness-checklist.md` and `ai-vendor-evaluation-checklist.md` have `faq` but no `howto` block; `policy-template-library.md` has neither. All three are ineligible for HowTo rich results. Adding `howto` frontmatter requires understanding page content — flagged for human action.

- **Content freshness** — `business-resources/ai-learning-development-directory.md` and `resources/australian-ai-community.md` are 102 days since last review (quarterly threshold: 100 days, overdue by 2 days). Review and update `last-reviewed` date.

- **External links** — Network access is unavailable in the audit environment (all requests return 403 at the proxy level). Cannot confirm link liveness this cycle. Carry-forward from May 3 report: `minister.industry.gov.au` links in `ai-learning-development-directory.md` point to an archived ministerial release (minister has changed) — flag for manual verification.

- **Title/description length** — Many pages fall outside the 50–60 char title / 150–160 char description targets. Requires keyword research to fix correctly; not auto-fixable.

- **og_image relative paths** — ~30 pages use relative `og_image` paths (e.g. `assets/safeaiaus-logo-600px.png`). Template compensates at render time, but CLAUDE.md specifies absolute URLs. Low-priority normalisation for a future pass.

Source: agent-engine/maintenance/seo-report-2026-05-13.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kh11wj1Ta5Q2F9rrmMjgSw)_