### PR TITLE
fix: Monthly SEO fixes 2026-06-07

### DIFF
--- a/docs/business-resources/ai-aus-tools-frameworks.md
+++ b/docs/business-resources/ai-aus-tools-frameworks.md
@@ -114,7 +114,7 @@ As part of the **APS AI Plan 2025**, the Australian Government's **GovAI Chat** 
 
 ## 🔍 RAG Evaluation & QA (Open-source)
 
-- **ragas** – evaluation for retrieval-augmented generation. ([github.com](https://github.com/explodinggradients/ragas))
+- **ragas** – evaluation for retrieval-augmented generation. ([github.com](https://github.com/vibrantlabsai/ragas))
 
 ## 🚀 Serving & Data Infrastructure (Open-source)
 

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -190,7 +190,7 @@ This glossary is published by **SafeAI-Aus** under [CC BY 4.0](https://creativec
   "@type": "DefinedTermSet",
   "name": "AI Glossary (Australia)",
   "inLanguage": "en-AU",
-  "url": "https://safeaiaus.org/glossary",
+  "url": "https://safeaiaus.org/resources/glossary/",
   "creator": { "@type": "Organization", "name": "SafeAI-Aus", "url": "https://safeaiaus.org" },
   "license": "https://creativecommons.org/licenses/by/4.0/"
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -102,4 +102,4 @@ Agents can poll `/updates.json` to discover what has changed since their last vi
 - GitHub: github.com/safeai-aus/safeai-aus.github.io
 
 ---
-Last updated: 2026-05-17
+Last updated: 2026-06-08

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@ license = "CC BY 4.0"
 repo = "https://github.com/safeai-aus/safeai-aus.github.io"
 website = "https://safeaiaus.org"
 policy-version = "1.2"
-last-updated = "2026-05-17"
+last-updated = "2026-06-08"
 changelog = "https://safeaiaus.org/updates.json"
 full-summary = "https://safeaiaus.org/llms-full.txt"
 


### PR DESCRIPTION
Automated fixes from the monthly SEO audit (2026-06-07 + 2026-06-08 + 2026-06-09 follow-up).

## Fixes applied

- **Broken redirect — ragas repo URL** (`docs/business-resources/ai-aus-tools-frameworks.md`): The ragas RAG evaluation library transferred from `github.com/explodinggradients/ragas` to `github.com/vibrantlabsai/ragas`. Updated to the new canonical URL.

- **Stale AI-crawler inventory dates** (`llms.txt`, `llms-full.txt`): Two content merges to main (PRs #104, #105) occurred after the May 17 last-updated date. Updated both files to 2026-06-08 so visiting LLMs and crawlers can correctly assess content freshness.

- **Wrong canonical URL in glossary JSON-LD schema** (`docs/resources/glossary.md`): The `DefinedTermSet` JSON-LD block had `url` set to `https://safeaiaus.org/glossary` — missing the `/resources/` path segment and trailing slash. Corrected to `https://safeaiaus.org/resources/glossary/` to match the `og_url` frontmatter and sitemap entry. Schema crawlers and LLMs reading this block now receive the correct canonical URL.

## Issues reported (not auto-fixed)

### Content freshness — overdue pages (requires human review)
- `business-resources/ai-learning-development-directory.md` — last-reviewed 2026-01-31 (129 days old, quarterly threshold 100 days)
- `resources/australian-ai-community.md` — last-reviewed 2026-01-31 (129 days old, quarterly threshold 100 days)

### On-page SEO — title/description length (requires keyword research, not auto-fixed)
Several pages have titles under 50 chars or descriptions over 160 chars. Most notable:
- `safety-standards/international-ai-legal-overview.md` — title 80 chars (over limit)
- `business-resources/state-territory-ai-resources.md` — description 215 chars
- `safety-standards/guidance-for-ai-adoption-ai6.md` — description 219 chars
- `governance-templates/ai-risk-assessment-checklist.md` — description 219 chars

### Schema gaps (requires content expertise, not auto-fixed)
- `governance-templates/ai-readiness-checklist.md` — missing `howto` frontmatter
- `governance-templates/ai-vendor-evaluation-checklist.md` — missing `howto` frontmatter
- Several business resource pages missing `faq` frontmatter (`agent-readable-resources`, `ai-aus-tools-frameworks`, `ai-learning-development-directory`, `index`, `state-territory-ai-resources`)

### External links — bot blocking (not broken)
All .gov.au URLs return 403 — consistent with server-side bot protection, not broken pages. Other external links also return 403 (e.g. creativecommons.org, iso.org). No 404s found across all external URLs checked.

### Internal linking
Most pages reachable only via top-level navigation (not inline content links) — by design given the site's nav-tab structure. Notable orphans with 0 incoming content links: `/business-resources/ai-governance-faq/`, `/business-resources/agent-readable-resources/`, `/resources/australian-ai-community/`. No immediate action required.

### Sitemap
About, contact and newsletter pages are built but not in the sitemap (not in nav). They have `robots: index, follow` set and are linked from the footer, so crawlers will find them. No `<lastmod>` dates in `site/sitemap.xml` — zensical build-system limitation, not a content issue.

Source: agent-engine/maintenance/seo-report-2026-06-09.md