### PR TITLE
Content update: 14 June 2026 digest — DTA deadline, OAIC ADM closure, Unfair Trading Practices Bill, EU Omnibus

### DIFF
--- a/docs/safety-standards/ai-australian-legislation.md
+++ b/docs/safety-standards/ai-australian-legislation.md
@@ -5,7 +5,7 @@ description: "Comprehensive overview of current legislation applicable to AI ado
 keywords: "AI legislation Australia, Australian AI law, AI privacy law, AI consumer law, AI discrimination law, AI intellectual property, AI legal compliance, Australian AI regulations, AI legal framework"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-05-19"
+last-reviewed: "2026-06-15"
 review-cycle: "quarterly"
 og_title: "Current Legal Landscape for AI in Australia"
 og_description: "Comprehensive overview of current legislation applicable to AI adoption in Australian business"
@@ -27,7 +27,7 @@ While Australia doesn't yet have AI-specific legislation, AI use is already gove
 In 2024 the Government released proposals for mandatory guardrails for high-risk AI applications alongside a Voluntary AI Safety Standard. In October 2025 the National AI Centre (NAIC) published updated **Guidance for AI Adoption**, which sets out six essential practices (AI6) and is now the primary government guidance for responsible AI governance and adoption. In December 2025 the **National AI Plan** confirmed that, for now, Australia will rely on **existing laws and sector regulators, supported by voluntary guidance and a new AI Safety Institute**, rather than introducing a standalone AI Act or immediate mandatory guardrails.
 
 !!! note "Policy is evolving"
-    The Australian AI policy landscape is changing rapidly. The information below reflects the position as of April 2026. For government policy, guidance and institutional developments, see [Australian Government AI Policy and Frameworks](ai-government-policy-frameworks.md). Monitor [industry.gov.au/ai](https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence) and the AI Safety Institute for updates.
+    The Australian AI policy landscape is changing rapidly. The information below reflects the position as of June 2026. For government policy, guidance and institutional developments, see [Australian Government AI Policy and Frameworks](ai-government-policy-frameworks.md). Monitor [industry.gov.au/ai](https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence) and the AI Safety Institute for updates.
 
 !!! info "Why This Matters"
     Understanding the current legal landscape helps organisations:
@@ -65,7 +65,7 @@ The **Privacy Act 1988** is the principal legislation that regulates how persona
 - The nature of decisions made solely or significantly by computer programs
 - Where those decisions could reasonably be expected to significantly affect individual rights or interests
 
-The OAIC is progressively publishing guidance on these new obligations throughout 2026. Organisations using AI in automated decision-making should begin privacy policy reviews now.
+The OAIC issued an issues paper on "Guidance for Transparency in Automated Decision Making" (published 18 May 2026; consultation closed 15 June 2026) to inform its formal guidance on these obligations. Formal OAIC guidance is expected by September 2026 ([oaic.gov.au](https://www.oaic.gov.au/engage-with-us/consultations/consultation-on-guidance-for-transparency-in-automated-decision-making), accessed 14 June 2026). Organisations using AI in automated decision-making should begin privacy policy reviews now in preparation for the December 2026 commencement.
 
 **Penalties:** Since 2022 reforms, serious or repeated breaches can attract penalties of up to the greater of $50 million, three times the benefit obtained, or 30% of adjusted turnover ([oaic.gov.au](https://www.oaic.gov.au/privacy/privacy-legislation/the-privacy-act)).
 
@@ -91,6 +91,8 @@ The **Australian Consumer Law (ACL)** is a national law embedded in the Competit
 **Regulatory context:** The ACCC is actively monitoring emerging AI-enabled practices, including reviews, claims and pricing models. In February 2026 the ACCC published its own AI transparency statement disclosing how it uses AI internally, and has flagged **"AI-washing"** (misleading claims about AI capabilities) as an enforcement concern. The Treasury's review of AI and the Australian Consumer Law found the existing framework "fit for purpose", making dedicated AI consumer legislation unlikely in the near term.
 
 **Penalty increase (effective 28 March 2026):** The **Treasury Laws Amendment (Doubling Penalties for ACCC Enforcement) Act 2026** doubled the maximum corporate penalty under the Competition and Consumer Act 2010 and the ACL from $50 million to **$100 million per contravention** for the most serious breaches. The amendment applies across all CCA/ACL provisions including misleading and deceptive conduct — the primary legal risk for businesses making unsubstantiated AI capability claims. The ACCC has publicly stated it will seek the highest penalties appropriate in cases it brings to court. The ACCC's 2026–27 enforcement priorities include manipulative conduct in digital markets (dark patterns, subscription traps, misleading pricing claims) — AI-enabled variants are within scope ([whitecase.com](https://www.whitecase.com/insight-alert/australia-increases-penalties-competition-and-consumer-law-breaches), [nortonrosefulbright.com](https://www.nortonrosefulbright.com/en-au/knowledge/publications/e88ea652/accc-confirms-2026-27-compliance-and-enforcement-priorities)).
+
+**Unfair Trading Practices Bill 2026 (introduced 1 April 2026):** The Competition and Consumer Amendment (Unfair Trading Practices) Bill 2026, introduced to the House of Representatives on 1 April 2026, proposes a general prohibition on unfair trading practices under the ACL, specific prohibitions on unfair subscription practices, and improved protections against drip pricing. The Government has explicitly stated that AI-enabled dark patterns and algorithmic manipulation of consumer choice are within scope. Maximum penalties include AUD $50 million, three times the benefit gained, or 30% of adjusted turnover during the breach period — whichever is greatest. Proposed commencement is 1 July 2027 (if passed). Working in tandem with the Doubling Penalties Act (effective 28 March 2026), the Bill creates a materially higher-risk environment for businesses using AI in consumer-facing contexts ([aph.gov.au](https://www.aph.gov.au/Parliamentary_Business/Bills_Legislation/Bills_Search_Results/Result?bId=r7468), accessed 14 June 2026).
 
 ---
 
@@ -149,14 +151,17 @@ Australia's **IP laws**—covering copyright, patents, trademarks and design rig
 
 ## Upcoming Legislative Reforms
 
+- 🏛️ **DTA mandatory AI requirements — first requirement in effect 15 June 2026**
+  The first mandatory obligation under the DTA's Policy for the Responsible Use of AI in Government (Version 2.0) came into effect on 15 June 2026: all non-corporate Commonwealth entities must maintain an internal register of in-scope AI use cases with an accountable owner for each. All 94 mandatory agencies published public AI transparency statements ahead of this date — 15 June 2026 marks the first concrete enforcement date in the DTA's AI policy framework. Mandatory foundational AI training for all APS staff also becomes a policy requirement from this date. Remaining DTA obligations commence December 2026: completing an AI Impact Assessment prior to deployment; implementing processes to assess, approve and oversee AI use cases; and reporting on AI incidents.
+
 - 🔒 **Privacy Act — automated decision-making transparency (10 December 2026)**
-  New APP 1.7–1.9 obligations require disclosure when computer programs use personal information to make decisions significantly affecting individuals. See the Privacy Act section above for details. The OAIC is publishing guidance progressively throughout 2026.
+  New APP 1.7–1.9 obligations require disclosure when computer programs use personal information to make decisions significantly affecting individuals. See the Privacy Act section above for details. The OAIC consultation on transparency guidance closed 15 June 2026; formal guidance is expected by September 2026.
 
 - 📝 **Copyright reform — TDM exemption rejected (April 2026)**
   Parliament rejected a text-and-data-mining exemption for AI training and is exploring a paid licensing model instead. See the IP section above for details. Further consultations on AI's impact on the creative sector are expected through the next National Cultural Policy process.
 
-- ⚖️ **Consumer law — no standalone AI legislation**
-  The Treasury review found the Australian Consumer Law "fit for purpose" for AI. No dedicated AI consumer legislation is expected in the near term. The ACCC continues to monitor AI-washing and misleading AI claims.
+- ⚖️ **Consumer law — Unfair Trading Practices Bill 2026 (introduced 1 April 2026)**
+  The Competition and Consumer Amendment (Unfair Trading Practices) Bill 2026, introduced 1 April 2026, explicitly targets AI-enabled dark patterns and algorithmic manipulation of consumer choice. Proposed commencement 1 July 2027 (if passed). See the Australian Consumer Law section above for details. The Treasury review also found the existing ACL "fit for purpose" for AI; no broader dedicated AI consumer legislation is expected in the near term.
 
 !!! info "Government Policy and Guidance"
     For coverage of the National AI Plan, AI Safety Institute, DTA mandatory requirements, Senate Committee response and other government policy developments, see [Australian Government AI Policy and Frameworks](ai-government-policy-frameworks.md).

--- a/docs/safety-standards/international-ai-legal-overview.md
+++ b/docs/safety-standards/international-ai-legal-overview.md
@@ -5,7 +5,7 @@ description: "Comprehensive overview of international AI regulations and legal f
 keywords: "international AI law, EU AI Act, US AI regulation, global AI compliance, AI legal landscape, Australian businesses abroad, AI regulation 2026"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-05-19"
+last-reviewed: "2026-06-15"
 review-cycle: "quarterly"
 og_title: "International AI Legal Landscape (2026) — What Australian Businesses Should Know"
 og_description: "Comprehensive overview of international AI regulations and legal frameworks for Australian businesses"
@@ -22,10 +22,10 @@ twitter_description: "Comprehensive overview of international AI regulations and
 > **Purpose:** Navigate international AI regulations affecting Australian organisations operating globally
 > **Audience:** Legal, compliance, international business and governance teams | **Time:** 60-90 minutes
 
-*Last updated: 19 May 2026. This page is informational and not legal advice.*
+*Last updated: 15 June 2026. This page is informational and not legal advice.*
 
 !!! note "Rapidly evolving landscape"
-    International AI regulations are changing fast. The EU's **Digital Omnibus on AI** reached provisional political agreement on 7 May 2026 (extending key AI Act compliance deadlines); formal adoption by the European Parliament is expected by 7 July 2026, with entry into force around end of July 2026. South Korea's AI Basic Act took effect in January 2026 with implementing rules still emerging. Canada's AIDA died on the Order Paper and any replacement may differ substantially. Always verify current status with official sources before making compliance decisions.
+    International AI regulations are changing fast. The EU's **Digital Omnibus on AI** reached provisional political agreement on 7 May 2026 (extending key AI Act compliance deadlines). The IMCO and LIBE committees of the European Parliament endorsed the agreement by **93 votes to 4 on 2 June 2026**, clearing the way for a full Parliament plenary vote now scheduled for **June 2026** — expected before the original 2 August 2026 high-risk AI deadline. South Korea's AI Basic Act took effect in January 2026 with implementing rules still emerging. Canada's AIDA died on the Order Paper and any replacement may differ substantially. Always verify current status with official sources before making compliance decisions.
 
 As AI regulation accelerates globally, many jurisdictions already impose binding requirements or have near-term obligations that will affect Australian organisations exporting, operating, or handling data linked to those regions.
 
@@ -76,12 +76,12 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
     - **Machinery Regulation:** moved to Annex I Section B — AI in machinery-regulated products falls primarily under the Machinery Regulation rather than direct AI Act high-risk requirements
     - **SME exemption** extended to small mid-cap companies (SMCs)
 
-    **Status:** Provisional only — formal adoption by the European Parliament is expected by **7 July 2026**, with entry into force around end of July 2026 (before the original 2 August 2026 high-risk AI deadline). Australian businesses supplying AI into the EU should plan to the new dates but not discontinue compliance work until formal adoption is confirmed. (Updated: 19 May 2026; sources: [consilium.europa.eu](https://www.consilium.europa.eu/en/press/press-releases/2026/05/07/artificial-intelligence-council-and-parliament-agree-to-simplify-and-streamline-rules/), [iapp.org](https://iapp.org/news/a/eu-agrees-to-amend-ai-act-clarifies-overlap-with-machinery-rules))
+    **Status:** Parliamentary committees (IMCO/LIBE) endorsed the provisional agreement by **93 votes to 4 on 2 June 2026**. Full Parliament plenary vote scheduled for **June 2026** (exact date pending) — expected to complete before the 2 August 2026 high-risk AI deadline, with entry into force around end of July 2026. Australian businesses supplying AI into the EU should plan to the new provisional dates but confirm once formally adopted. (Updated: 15 June 2026; sources: [consilium.europa.eu](https://www.consilium.europa.eu/en/press/press-releases/2026/05/07/artificial-intelligence-council-and-parliament-agree-to-simplify-and-streamline-rules/), [agenceurope.eu](https://agenceurope.eu/en/bulletin/article/13879/32/provisional-agreement-on-digital-omnibus-gets-green-light-from-european-parliaments-competent-committees), [iapp.org](https://iapp.org/news/a/eu-agrees-to-amend-ai-act-clarifies-overlap-with-machinery-rules))
 
 !!! warning "What to Do"
     - ✅ Map any **EU-facing** AI systems to risk categories; identify if you're a **provider**, **deployer**, **importer** or **distributor**
     - ✅ For **GPAI/models**, prepare **training-data summaries**, technical documentation and risk-mitigation processes (red-teaming, incident reporting)
-    - ✅ Plan to the **provisional Omnibus dates** (2 December 2027 for Annex III; 2 August 2028 for Annex I); be ready to confirm once the European Parliament formally adopts the text (vote expected by 7 July 2026). Until then, treat the new dates as planning assumptions rather than legal certainty.
+    - ✅ Plan to the **provisional Omnibus dates** (2 December 2027 for Annex III; 2 August 2028 for Annex I); be ready to confirm once the European Parliament formally adopts the text (plenary vote expected June 2026, following the 93–4 committee endorsement on 2 June 2026). Until then, treat the new dates as planning assumptions rather than legal certainty.
 
 ### United States (US)
 
@@ -146,7 +146,7 @@ States and cities are active: **Colorado SB24-205** (effective **30 June 2026**,
 
 ## Side-by-Side Summary
 
-| Jurisdiction | Legal posture (Apr 2026) | Primary instruments | Key dates | Headline obligations (examples) |
+| Jurisdiction | Legal posture (Jun 2026) | Primary instruments | Key dates | Headline obligations (examples) |
 |---|---|---|---|---|
 | **EU** | Binding, phased | EU AI Act; EU Digital Omnibus (provisional agreement 7 May 2026) | Feb 2025 (bans); Aug 2025 (GPAI); **Dec 2027** (Annex III high-risk) and **Aug 2028** (Annex I embedded) per provisional Omnibus extensions; watermarking and NCII prohibition Dec 2026 | Risk-tiered duties, GPAI transparency/docs, post-market monitoring, penalties up to 7% turnover |
 | **US** | Patchwork + federal guidance | NIST AI RMF; OMB M-24-10; **Colorado AI Act**; NYC AEDT law | **CO:** 30 June 2026; **NYC AEDT:** in force | Risk programs, **impact assessments**, notices, bias audits (hiring), consumer appeal/human review |

--- a/docs/safety-standards/voluntary-ai-safety-standard-10-guardrails.md
+++ b/docs/safety-standards/voluntary-ai-safety-standard-10-guardrails.md
@@ -38,6 +38,8 @@ Importantly, the 10 guardrails are consistent with leading international standar
 
     The 10 guardrails on this page remain fully integrated into the new guidance and are best used as a **detailed control set** and historical reference, especially where contracts, risk registers or external frameworks still refer to the original VAISS guardrails.
 
+    **VAISS v2 update (as of June 2026):** The Expression of Interest for VAISS v2 consultations (consult.industry.gov.au) opened 15 December 2024 and closed 10 January 2025; consultation sessions ran January–February 2025. No standalone VAISS v2 document was published. The planned additions (content labelling and watermarking guidance, developer-facing guardrails, procurement guidance) were incorporated into the AI6 Implementation Practices document (October 2025). The AI6 guidance is the current authoritative reference; no further standalone VAISS v2 release is expected.
+
 ## Why this matters
 
 Adopting the guardrails early helps organisations build **trust, resilience and regulatory readiness**. By embedding these practices now, businesses can:


### PR DESCRIPTION
## Summary

Content updates based on the weekly researcher digest (14 June 2026).

### Changes made

- **`docs/safety-standards/ai-australian-legislation.md`**
  - Added DTA mandatory AI requirements now in effect (15 June 2026): first mandatory obligation (internal AI use case register with accountable owners) in force for all 94 non-corporate Commonwealth entities; APS mandatory foundational AI training also begins 15 June 2026; remaining DTA obligations (impact assessments, oversight processes, incident reporting) commence December 2026.
  - Added OAIC ADM consultation closure: OAIC issues paper on "Guidance for Transparency in Automated Decision Making" closed 15 June 2026; formal guidance expected September 2026, ahead of the ADM transparency obligation commencing 10 December 2026.
  - Added Competition and Consumer Amendment (Unfair Trading Practices) Bill 2026 (introduced 1 April 2026) to the ACL section: explicitly targets AI-enabled dark patterns and algorithmic manipulation; proposed commencement 1 July 2027 (if passed); max penalty AUD $50M or 30% adjusted turnover. Complements the Doubling Penalties Act already on the page.
  - Updated "Policy is evolving" note from April 2026 to June 2026.
  - Updated `last-reviewed` to 2026-06-15.

- **`docs/safety-standards/international-ai-legal-overview.md`**
  - Updated EU AI Act Digital Omnibus status: IMCO/LIBE committees endorsed by 93 votes to 4 on 2 June 2026; Parliament plenary vote now scheduled June 2026 (earlier than previously reported July). Updated "rapidly evolving landscape" note, EU info box status line, and What-to-Do callout.
  - Updated summary table header from Apr 2026 to Jun 2026.
  - Updated `last-reviewed` to 2026-06-15.

- **`docs/safety-standards/voluntary-ai-safety-standard-10-guardrails.md`**
  - Added VAISS v2 EOI confirmed closed (10 January 2025); no standalone v2 published; planned additions incorporated into AI6 (October 2025). Resolves the 403-error uncertainty flagged in prior digests.

### Flagged for manual action

- **AISI formal launch** (ninth consecutive week without confirmed announcement): Manual check recommended at industry.gov.au and minister.industry.gov.au media releases. Update the legislation page once an official launch announcement is confirmed.
- **EU AI Act Omnibus plenary vote**: The plenary vote result is expected imminently (June 2026). Once confirmed, the international overview page status note ("pending Official Journal publication") should be updated to reflect formal adoption.
- **APS training 30 June 2026 completion deadline**: Multiple sources indicate an expectation of 30 June 2026 as a completion target for APS-wide AI training, but this was not confirmed by primary sources (digital.gov.au returned HTTP 403). Manual verification recommended at digital.gov.au or apsacademy.gov.au.
- **SA AI Strategy**: Release date not announced. Update `docs/business-resources/state-territory-ai-resources.md` when released.

### Not actioned (by design)

- NSW Digital Work Systems Act — SafeWork NSW guidelines still pending; no commencement date to add.
- Privacy Act Tranche 2 — no bill introduced; monitoring only.
- Digital Competition Regime — Treasury consultation closed February 2026; no bill introduced yet.
- ACCC 2026–27 enforcement priorities — no new AI-specific actions announced.
- OAIC Children's Online Privacy Code — consultation closed 5 June 2026; OAIC reviewing ahead of December 2026 registration; monitoring only.
- Grant table carries forward with no changes (no new programs this week; CRC-P Round 19 and CRC Round 27 outcomes pending).

## Source

Researcher digest: `agent-engine/research/weekly-digest-2026-06-14.md`

**Ready for review.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01WT9ZxQuz76LEjszG5XFtEZ)_