### PR TITLE
content: DTA first mandatory AI requirement now in effect

### DIFF
--- a/docs/business-resources/ai-aus-tools-frameworks.md
+++ b/docs/business-resources/ai-aus-tools-frameworks.md
@@ -4,7 +4,7 @@ title: "AI Tools & Frameworks for Australian Businesses"
 description: "Curated collection of AI tools, frameworks and resources for Australian businesses implementing AI safely and responsibly. Includes risk management, governance and technical testing tools."
 keywords: "AI tools Australia, AI frameworks Australia, AI risk management tools, AI governance tools, AI testing tools, Australian AI resources, AI safety tools, AI compliance tools"
 author: "SafeAI-Aus"
-last-reviewed: "2026-05-19"
+last-reviewed: "2026-06-15"
 review-cycle: "quarterly"
 robots: "index, follow"
 og_title: "AI Tools & Frameworks for Australian Businesses"
@@ -31,8 +31,8 @@ A curated list of practical tools, frameworks and resources to help Australian b
 
 ---
 
-!!! info "Time-sensitive: 27 days to first mandatory DTA AI deadline"
-    The DTA's mandatory AI requirements for Australian Government agencies take effect on **15 June 2026** — 27 days away as at 19 May 2026. Commonwealth agencies should have AI Impact Assessment processes, staff training and transparency statements in place before this date. (Updated: 19 May 2026)
+!!! info "First mandatory DTA AI requirement now in effect (15 June 2026)"
+    The first mandatory AI requirement for Australian Government agencies came into effect on **15 June 2026**: all non-corporate Commonwealth entities must maintain an internal register of in-scope AI use cases with an accountable owner for each. All 94 mandatory agencies published public AI transparency statements ahead of this date. Remaining requirements (AI Impact Assessments, mandatory staff training, oversight processes and incident reporting) commence December 2026. (Updated: 15 June 2026)
 
 ## 🏛️ DTA AI Impact Assessment Tool (Commonwealth)
 


### PR DESCRIPTION
## What

The Tools & Frameworks page carried a stale countdown callout: *"27 days to first mandatory DTA AI deadline … 27 days away as at 19 May 2026."* That deadline (15 June 2026) has now passed and the first mandatory requirement is in effect.

This rewrites the callout to "in effect" framing, consistent with the legislation page (landed in #110), and bumps `last-reviewed` to 2026-06-15.

## Why separate from #111

This is pre-existing content that predates the #106/#107 salvage. Caught by the Codex review on #111, but fixed on its own branch so #111 stays scoped to the salvaged items. Single-file change.

## Checklist
- [x] Australian English
- [x] No em dashes (brand rule)
- [x] Framing matches the in-effect wording already on the legislation page
- [x] One file changed