### PR TITLE
content-update/2026-06-21 — Victoria pre-accelerators and ARC grant

### DIFF
--- a/docs/business-resources/ai-grants-funding-australia.md
+++ b/docs/business-resources/ai-grants-funding-australia.md
@@ -5,7 +5,7 @@ description: "Comprehensive guide to AI grants, funding programs and financial s
 keywords: "AI grants Australia, AI funding Australia, AI business grants, Australian AI funding, AI government grants, AI business support, AI investment Australia, AI startup funding"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-06-15"
+last-reviewed: "2026-06-22"
 review-cycle: "quarterly"
 og_title: "AI Grants and Funding Opportunities for Australian Businesses"
 og_description: "Comprehensive guide to AI grants, funding programs and financial support for Australian businesses"
@@ -31,7 +31,7 @@ twitter_description: "Comprehensive guide to AI grants, funding programs and fin
 AI is reshaping industries across Australia. To support businesses in responsibly adopting and scaling AI, a mix of government grants, research programs and industry‑backed accelerators are available. This article provides a consolidated overview of the most relevant opportunities for Australian businesses today.
 
 !!! warning "Program status changes frequently"
-    Government programs open, close and change eligibility regularly. **Always verify current status** with the relevant funding body before investing time in an application. Last reviewed: April 2026.
+    Government programs open, close and change eligibility regularly. **Always verify current status** with the relevant funding body before investing time in an application. Last reviewed: June 2026.
 
 ---
 
@@ -73,6 +73,11 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 - **Linkage Projects**: Promote industry–academic partnerships; in 2024 Round 2, $46.6m was awarded to 75 projects. The 2026 Linkage Projects round closed 18 March 2026.
 - Program is **active and ongoing**.
 - ➡️ [Discovery Projects](https://www.arc.gov.au/funding-research/discovery-linkage/discovery-program/discovery-projects) | [Linkage Projects](https://www.arc.gov.au/funding-research/funding-schemes/linkage-program/linkage-projects)
+
+!!! info "ARC Discovery Indigenous 2027 — Now Open (closes 25 August 2026)"
+    The ARC Discovery Indigenous 2027 scheme opened 2 June 2026 and closes **25 August 2026 at 5:00 pm AEST**. The scheme supports research projects led by Aboriginal and/or Torres Strait Islander researchers (as Chief Investigator) across all disciplines; non-Indigenous researchers may participate as Partner Investigators. The scheme is not AI-specific but is relevant to AI research grant pipelines at institutions with eligible researchers.
+
+    ➡️ [ARC Discovery Indigenous 2027](https://www.arc.gov.au/news-and-publications/media/now-open-applications-discovery-indigenous-2027) (accessed 21 June 2026)
 
 !!! info "ARC Generative AI Policy — effective 28 April 2026"
     The Australian Research Council (jointly with the NHMRC) released an updated **Policy on Use of Generative Artificial Intelligence in the ARC's Grants Programs** in April 2026. The policy applies to all applications and assessments for ARC scheme rounds opening from **28 April 2026**.
@@ -167,13 +172,14 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 - Programs are active.
 - ➡️ [Grant recipients](https://science.desi.qld.gov.au/industry/quantum/programs/grant-recipients)
 
-### Victoria: LaunchVic AI-Specific Programs
+### Victoria: AI and Deeptech Pre-Accelerators (LaunchVic, $3.5M)
 
-- Funding for AI-focused accelerators and pre-accelerators.
-- Support for AI startups through sector-specific programs.
-- Investment in AI-focused angel networks and VC funds.
-- Programs are active and ongoing.
-- ➡️ [LaunchVic programs](https://launchvic.org/programs/)
+- The Victorian Government announced **$3.5 million** to fund nine AI and deeptech pre-accelerator programs on **17 June 2026**.
+- Funding flows to program operators (not direct startup grants); each of the nine providers receives up to $400,000. Providers include Boab AI, Boson Ventures, Cicada Innovations, CoLabs Australia, HEX, Illume Ventures, Jumpstart Studio, MedTech Actuator and RMIT DiscoveryHUB.
+- A featured program is **VICTOR:AI** — an eight-week cohort for AI-native startups offering AI tools, co-working space and milestone-based grants.
+- Startups apply directly to their relevant program provider; this is not an open competitive grant round.
+- Programs are **active** (funding disbursed to operators as of June 2026).
+- ➡️ [Victorian Government announcement](https://djsir.vic.gov.au/news-and-articles/victoria-backs-the-next-generation-of-ai-and-deeptech-startups) | [LaunchVic programs](https://launchvic.org/programs/)
 
 ---
 
@@ -233,11 +239,12 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 | Catalysing AI in Regions | Federal Grant | $250k–$500k | Regional AI solutions | Concluded |
 | R&D Tax Incentive | Tax Offset | 38.5–43.5% | AI R&D projects | Active |
 | ARC Discovery & Linkage | Competitive grants | $30k–$500k annually | University–industry research | Active |
+| ARC Discovery Indigenous 2027 | Competitive grant | Varies per project | Research led by Aboriginal/Torres Strait Islander researchers | Open — closes 25 Aug 2026 |
 | SA AI Initiative | State Program | $28m over 4 years | Healthcare, policing, services | Active (2025-2029) |
 | AIML Industrial AI SME Grant | SME Grant | Expert access | Industrial AI adoption | Active (to 2028) |
 | NSW Early Adopter Program | State Grant | $2.7m+ (2024) | Planning system AI trials | Active (2024) |
 | QLD Quantum & Advanced Tech | State Program | $53m | Quantum/AI infrastructure | Active |
-| VIC LaunchVic AI Programs | State Support | Varies | AI startup ecosystem | Active |
+| VIC AI and Deeptech Pre-Accelerators (LaunchVic, $3.5M) | State Program | $3.5m total ($400k/provider) | AI and deeptech startup pre-acceleration | Active (funded June 2026) |
 | MRFF AI in Health | Federal Grant | $30m | Healthcare AI transformation | Active |
 | CSIRO Next Gen Graduates | Federal Program | Varies | AI workforce development | Active |
 | CSIRO-NSF AI Collaboration | International Grant | $9.6m (2023) | Responsible AI research | Active |
@@ -322,7 +329,7 @@ AI is reshaping industries across Australia. To support businesses in responsibl
     - Queensland: Quantum and advanced technologies focus
     - South Australia: Public sector AI applications
     - NSW: Council planning systems and civic applications
-    - Victoria: Startup ecosystem development via LaunchVic
+    - Victoria: AI and deeptech pre-accelerators (nine programs funded June 2026)
 
     **Strengthen your application** by:
 

--- a/docs/business-resources/ai-grants-funding-australia.md
+++ b/docs/business-resources/ai-grants-funding-australia.md
@@ -5,7 +5,7 @@ description: "Comprehensive guide to AI grants, funding programs and financial s
 keywords: "AI grants Australia, AI funding Australia, AI business grants, Australian AI funding, AI government grants, AI business support, AI investment Australia, AI startup funding"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-06-22"
+last-reviewed: "2026-06-15"
 review-cycle: "quarterly"
 og_title: "AI Grants and Funding Opportunities for Australian Businesses"
 og_description: "Comprehensive guide to AI grants, funding programs and financial support for Australian businesses"
@@ -31,7 +31,7 @@ twitter_description: "Comprehensive guide to AI grants, funding programs and fin
 AI is reshaping industries across Australia. To support businesses in responsibly adopting and scaling AI, a mix of government grants, research programs and industry‑backed accelerators are available. This article provides a consolidated overview of the most relevant opportunities for Australian businesses today.
 
 !!! warning "Program status changes frequently"
-    Government programs open, close and change eligibility regularly. **Always verify current status** with the relevant funding body before investing time in an application. Last reviewed: June 2026.
+    Government programs open, close and change eligibility regularly. **Always verify current status** with the relevant funding body before investing time in an application. Last reviewed: April 2026.
 
 ---
 
@@ -78,6 +78,8 @@ AI is reshaping industries across Australia. To support businesses in responsibl
     The ARC Discovery Indigenous 2027 scheme opened 2 June 2026 and closes **25 August 2026 at 5:00 pm AEST**. The scheme supports research projects led by Aboriginal and/or Torres Strait Islander researchers (as Chief Investigator) across all disciplines; non-Indigenous researchers may participate as Partner Investigators. The scheme is not AI-specific but is relevant to AI research grant pipelines at institutions with eligible researchers.
 
     ➡️ [ARC Discovery Indigenous 2027](https://www.arc.gov.au/news-and-publications/media/now-open-applications-discovery-indigenous-2027) (accessed 21 June 2026)
+
+<!-- TODO(human verification): Recheck the ARC Discovery Indigenous 2027 status after its stated 25 August 2026 closing date. -->
 
 !!! info "ARC Generative AI Policy — effective 28 April 2026"
     The Australian Research Council (jointly with the NHMRC) released an updated **Policy on Use of Generative Artificial Intelligence in the ARC's Grants Programs** in April 2026. The policy applies to all applications and assessments for ARC scheme rounds opening from **28 April 2026**.
@@ -175,11 +177,12 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 ### Victoria: AI and Deeptech Pre-Accelerators (LaunchVic, $3.5M)
 
 - The Victorian Government announced **$3.5 million** to fund nine AI and deeptech pre-accelerator programs on **17 June 2026**.
-- Funding flows to program operators (not direct startup grants); each of the nine providers receives up to $400,000. Providers include Boab AI, Boson Ventures, Cicada Innovations, CoLabs Australia, HEX, Illume Ventures, Jumpstart Studio, MedTech Actuator and RMIT DiscoveryHUB.
+- The announced funding is for program operators rather than direct startup grants. The announcement says each provider may receive up to $400,000. Providers include Boab AI, Boson Ventures, Cicada Innovations, CoLabs Australia, HEX, Illume Ventures, Jumpstart Studio, MedTech Actuator and RMIT DiscoveryHUB.
 - A featured program is **VICTOR:AI** — an eight-week cohort for AI-native startups offering AI tools, co-working space and milestone-based grants.
-- Startups apply directly to their relevant program provider; this is not an open competitive grant round.
-- Programs are **active** (funding disbursed to operators as of June 2026).
+- Provider intake arrangements and timing vary. The Victorian Government announcement did not specify which programs were accepting applications or confirm that funding had been disbursed.
 - ➡️ [Victorian Government announcement](https://djsir.vic.gov.au/news-and-articles/victoria-backs-the-next-generation-of-ai-and-deeptech-startups) | [LaunchVic programs](https://launchvic.org/programs/)
+
+<!-- TODO(human verification): Recheck provider intake status and timing before describing any program as open or active; the 17 June 2026 announcement did not provide application dates. -->
 
 ---
 
@@ -244,7 +247,7 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 | AIML Industrial AI SME Grant | SME Grant | Expert access | Industrial AI adoption | Active (to 2028) |
 | NSW Early Adopter Program | State Grant | $2.7m+ (2024) | Planning system AI trials | Active (2024) |
 | QLD Quantum & Advanced Tech | State Program | $53m | Quantum/AI infrastructure | Active |
-| VIC AI and Deeptech Pre-Accelerators (LaunchVic, $3.5M) | State Program | $3.5m total ($400k/provider) | AI and deeptech startup pre-acceleration | Active (funded June 2026) |
+| VIC AI and Deeptech Pre-Accelerators (LaunchVic, $3.5M) | State Program | $3.5m announced (up to $400k/provider) | AI and deeptech startup pre-acceleration | Operators announced 17 Jun 2026; provider intake varies |
 | MRFF AI in Health | Federal Grant | $30m | Healthcare AI transformation | Active |
 | CSIRO Next Gen Graduates | Federal Program | Varies | AI workforce development | Active |
 | CSIRO-NSF AI Collaboration | International Grant | $9.6m (2023) | Responsible AI research | Active |
@@ -329,7 +332,7 @@ AI is reshaping industries across Australia. To support businesses in responsibl
     - Queensland: Quantum and advanced technologies focus
     - South Australia: Public sector AI applications
     - NSW: Council planning systems and civic applications
-    - Victoria: AI and deeptech pre-accelerators (nine programs funded June 2026)
+    - Victoria: AI and deeptech pre-accelerators (nine operators announced June 2026; provider intake varies)
 
     **Strengthen your application** by:
 

--- a/docs/business-resources/state-territory-ai-resources.md
+++ b/docs/business-resources/state-territory-ai-resources.md
@@ -5,7 +5,7 @@ description: "Comprehensive guide to AI resources published by Australian federa
 keywords: "Australian government AI resources, federal AI policy, state AI policies, territory AI policies, government AI strategies, NAIC, OAIC, DTA, NSW AI policy, Victoria AI guidance, Queensland AI framework, SA AI resources, WA AI policy, Tasmania AI guidance, ACT AI policy, NT AI framework"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-06-15"
+last-reviewed: "2026-06-22"
 review-cycle: "quarterly"
 og_title: "Australian Government AI Resources (Federal, State & Territory)"
 og_description: "Comprehensive guide to AI resources published by Australian federal, state and territory governments"
@@ -24,7 +24,7 @@ twitter_description: "Comprehensive guide to AI resources published by Australia
 
 This page curates official Australian government resources on AI for public sector use, covering federal agencies and all states and territories. It focuses on whole-of-government strategies and policies, AI assurance frameworks, information/privacy guidance from statutory bodies (e.g., information commissioners, ombudsmen) and records management directives. Where education-specific positions exist, they're included because they are often the most mature sector guidance.
 
-> **Last verified:** February 2026. Links point only to official government or statutory sources.
+> **Last verified:** June 2026. Links point only to official government or statutory sources.
 
 ---
 
@@ -102,6 +102,13 @@ For a detailed overview of Australian AI legislation, see our [AI & Australian L
 - **[Public Record Office Victoria — AI Technologies & Recordkeeping Policy](https://prov.vic.gov.au/recordkeeping-government/document-library/ai-technologies-policy-ai-technologies-and-recordkeeping)** — mandatory recordkeeping directives for AI.
 - **[Victorian Public Sector Data Sharing Framework](https://www.vic.gov.au/victorian-public-sector-data-sharing-framework)** — principles and practice for data sharing that supports safe AI use.
 - **[Policies & standards for government IT (consolidated library)](https://www.vic.gov.au/policies-standards-for-government-IT)** — whole-of-VPS ICT policy library relevant to AI governance.
+
+!!! info "Victoria — $3.5M AI and Deeptech Pre-Accelerator Initiative (announced 17 June 2026)"
+    The Victorian Government announced $3.5 million to fund nine pre-accelerator programs for AI and deeptech startups at the Victorian Startup Gala on 17 June 2026. Funding flows to program operators (not directly to startups), with each of the nine providers receiving up to $400,000. Funded providers are: Boab AI, Boson Ventures, Cicada Innovations, CoLabs Australia, HEX, Illume Ventures, Jumpstart Studio, MedTech Actuator, and RMIT DiscoveryHUB.
+
+    A featured program is **VICTOR:AI** — an eight-week cohort for AI-native startups offering access to AI tools, co-working space and milestone-based grants. This initiative is consistent with Victoria's **AI Mission Statement** (announced 30 January 2026), positioning Victoria as a national AI leader.
+
+    Startups should identify their relevant program provider and apply directly. See [djsir.vic.gov.au](https://djsir.vic.gov.au/news-and-articles/victoria-backs-the-next-generation-of-ai-and-deeptech-startups) for the full provider list and program details (accessed 21 June 2026).
 
 ---
 

--- a/docs/business-resources/state-territory-ai-resources.md
+++ b/docs/business-resources/state-territory-ai-resources.md
@@ -5,7 +5,7 @@ description: "Comprehensive guide to AI resources published by Australian federa
 keywords: "Australian government AI resources, federal AI policy, state AI policies, territory AI policies, government AI strategies, NAIC, OAIC, DTA, NSW AI policy, Victoria AI guidance, Queensland AI framework, SA AI resources, WA AI policy, Tasmania AI guidance, ACT AI policy, NT AI framework"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-06-22"
+last-reviewed: "2026-06-15"
 review-cycle: "quarterly"
 og_title: "Australian Government AI Resources (Federal, State & Territory)"
 og_description: "Comprehensive guide to AI resources published by Australian federal, state and territory governments"
@@ -24,7 +24,7 @@ twitter_description: "Comprehensive guide to AI resources published by Australia
 
 This page curates official Australian government resources on AI for public sector use, covering federal agencies and all states and territories. It focuses on whole-of-government strategies and policies, AI assurance frameworks, information/privacy guidance from statutory bodies (e.g., information commissioners, ombudsmen) and records management directives. Where education-specific positions exist, they're included because they are often the most mature sector guidance.
 
-> **Last verified:** June 2026. Links point only to official government or statutory sources.
+> **Last verified:** February 2026. Links point only to official government or statutory sources.
 
 ---
 
@@ -104,11 +104,13 @@ For a detailed overview of Australian AI legislation, see our [AI & Australian L
 - **[Policies & standards for government IT (consolidated library)](https://www.vic.gov.au/policies-standards-for-government-IT)** — whole-of-VPS ICT policy library relevant to AI governance.
 
 !!! info "Victoria — $3.5M AI and Deeptech Pre-Accelerator Initiative (announced 17 June 2026)"
-    The Victorian Government announced $3.5 million to fund nine pre-accelerator programs for AI and deeptech startups at the Victorian Startup Gala on 17 June 2026. Funding flows to program operators (not directly to startups), with each of the nine providers receiving up to $400,000. Funded providers are: Boab AI, Boson Ventures, Cicada Innovations, CoLabs Australia, HEX, Illume Ventures, Jumpstart Studio, MedTech Actuator, and RMIT DiscoveryHUB.
+    The Victorian Government announced $3.5 million for nine pre-accelerator program operators supporting AI and deeptech startups at the Victorian Startup Gala on 17 June 2026. The announced funding is for operators rather than direct startup grants, with each provider eligible for up to $400,000. The operators are Boab AI, Boson Ventures, Cicada Innovations, CoLabs Australia, HEX, Illume Ventures, Jumpstart Studio, MedTech Actuator and RMIT DiscoveryHUB.
 
     A featured program is **VICTOR:AI** — an eight-week cohort for AI-native startups offering access to AI tools, co-working space and milestone-based grants. This initiative is consistent with Victoria's **AI Mission Statement** (announced 30 January 2026), positioning Victoria as a national AI leader.
 
-    Startups should identify their relevant program provider and apply directly. See [djsir.vic.gov.au](https://djsir.vic.gov.au/news-and-articles/victoria-backs-the-next-generation-of-ai-and-deeptech-startups) for the full provider list and program details (accessed 21 June 2026).
+    Provider intake arrangements and timing vary. The announcement did not specify which programs were accepting applications or confirm that funding had been disbursed. See [djsir.vic.gov.au](https://djsir.vic.gov.au/news-and-articles/victoria-backs-the-next-generation-of-ai-and-deeptech-startups) for the provider list and announced program details (accessed 21 June 2026).
+
+    <!-- TODO(human verification): Recheck provider intake status and timing before describing any program as open or active; the 17 June 2026 announcement did not provide application dates. -->
 
 ---
 

--- a/docs/safety-standards/international-ai-legal-overview.md
+++ b/docs/safety-standards/international-ai-legal-overview.md
@@ -5,7 +5,7 @@ description: "Comprehensive overview of international AI regulations and legal f
 keywords: "international AI law, EU AI Act, US AI regulation, global AI compliance, AI legal landscape, Australian businesses abroad, AI regulation 2026"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-06-15"
+last-reviewed: "2026-06-22"
 review-cycle: "quarterly"
 og_title: "International AI Legal Landscape (2026) — What Australian Businesses Should Know"
 og_description: "Comprehensive overview of international AI regulations and legal frameworks for Australian businesses"
@@ -22,10 +22,10 @@ twitter_description: "Comprehensive overview of international AI regulations and
 > **Purpose:** Navigate international AI regulations affecting Australian organisations operating globally
 > **Audience:** Legal, compliance, international business and governance teams | **Time:** 60-90 minutes
 
-*Last updated: 15 June 2026. This page is informational and not legal advice.*
+*Last updated: 22 June 2026. This page is informational and not legal advice.*
 
 !!! note "Rapidly evolving landscape"
-    International AI regulations are changing fast. The EU's **Digital Omnibus on AI** reached provisional political agreement on 7 May 2026 (extending key AI Act compliance deadlines). The IMCO and LIBE committees of the European Parliament endorsed the agreement by **93 votes to 4 on 2 June 2026**, clearing the way for a full Parliament plenary vote now scheduled for **June 2026** — expected before the original 2 August 2026 high-risk AI deadline. South Korea's AI Basic Act took effect in January 2026 with implementing rules still emerging. Canada's AIDA died on the Order Paper and any replacement may differ substantially. Always verify current status with official sources before making compliance decisions.
+    International AI regulations are changing fast. The EU's **Digital Omnibus on AI** completed its European Parliament plenary vote on **16 June 2026** (423 in favour, 57 against, 174 abstentions) — the last parliamentary step before formal Council adoption, which is expected before **2 August 2026**. Once published in the Official Journal (anticipated late July 2026), the revised deadlines and new obligations enter into force. South Korea's AI Basic Act took effect in January 2026 with implementing rules still emerging. Canada's AIDA died on the Order Paper and any replacement may differ substantially. Always verify current status with official sources before making compliance decisions.
 
 As AI regulation accelerates globally, many jurisdictions already impose binding requirements or have near-term obligations that will affect Australian organisations exporting, operating, or handling data linked to those regions.
 
@@ -36,7 +36,7 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 ## Executive Snapshot
 
 !!! info "Key Jurisdictions at a Glance"
-    - 🇪🇺 **EU** — The **EU AI Act** is in force with staged obligations. Bans on "unacceptable risk" uses started **2 Feb 2025**; **general-purpose AI (GPAI)** duties started **2 Aug 2025**. The **EU Digital Omnibus on AI** reached **provisional political agreement on 7 May 2026**, extending key deadlines: high-risk standalone AI (Annex III) now **2 December 2027**; high-risk AI embedded in products (Annex I) now **2 August 2028**; watermarking and a new NCII/CSAM prohibition now **2 December 2026**; sandboxes now **2 August 2027**. Formal adoption (European Parliament vote) expected by **7 July 2026**, before the original 2 August 2026 deadline. Plan to the provisional dates but be ready to confirm once formally adopted.
+    - 🇪🇺 **EU** — The **EU AI Act** is in force with staged obligations. Bans on "unacceptable risk" uses started **2 Feb 2025**; **general-purpose AI (GPAI)** duties started **2 Aug 2025**. The **EU Digital Omnibus on AI** was adopted by the European Parliament on **16 June 2026** (423–57), extending key deadlines: high-risk standalone AI (Annex III) now **2 December 2027**; high-risk AI embedded in products (Annex I) now **2 August 2028**; watermarking and a new NCII/CSAM prohibition now **2 December 2026**; sandboxes now **2 August 2027**. Council adoption remains the sole outstanding step, expected before **2 August 2026**. Plan to the revised deadlines; flag as pending Official Journal publication.
 
     - 🇺🇸 **US** — No single federal AI law. Federal direction runs through **NIST AI RMF 1.0** and public-sector guidance (**OMB M-24-10**). States are moving: **Colorado's AI Act** (effective **30 June 2026**) requires risk programs, impact assessments and notices for "high-risk" AI. NYC mandates bias audits for automated hiring tools.
 
@@ -63,9 +63,9 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 
 ### European Union (EU)
 
-**Status & scope:** The **EU AI Act (Regulation (EU) 2024/1689)** is live with a **risk-tiered** regime (prohibited, high, limited, minimal), dedicated **GPAI** obligations and strong enforcement (up to 7% global turnover). Key dates under the **original Act** (before the 7 May 2026 Omnibus provisional agreement): **2 Feb 2025** (prohibitions), **2 Aug 2025** (GPAI, governance/penalties), **2 Aug 2026** (bulk compliance for high-risk AI systems under Annex III, transparency obligations under Article 50 and national/EU-level enforcement). Under the provisional Omnibus extensions (see callout below), the Annex III and Article 50 dates are now expected to move to **2 December 2027** and **2 December 2026** respectively, pending formal adoption.
+**Status & scope:** The **EU AI Act (Regulation (EU) 2024/1689)** is live with a **risk-tiered** regime (prohibited, high, limited, minimal), dedicated **GPAI** obligations and strong enforcement (up to 7% global turnover). Key dates under the **original Act**: **2 Feb 2025** (prohibitions), **2 Aug 2025** (GPAI, governance/penalties), **2 Aug 2026** (bulk compliance for high-risk AI systems under Annex III, transparency obligations under Article 50 and national/EU-level enforcement). The **EU Digital Omnibus on AI** was adopted by the European Parliament on **16 June 2026** (see callout below). Pending Council adoption and Official Journal publication (anticipated late July 2026), the Annex III and Article 50 deadlines are confirmed to move to **2 December 2027** and **2 December 2026** respectively.
 
-!!! info "EU Digital Omnibus on AI — Provisional agreement reached 7 May 2026"
+!!! info "EU Digital Omnibus on AI — Parliament adopted 16 June 2026; Council adoption pending"
     The **EU Digital Omnibus on AI** reached provisional political agreement at the third trilogue between the European Parliament and the Council on **7 May 2026**. Provisional extensions agreed at trilogue (subject to formal adoption):
 
     - **High-risk AI standalone systems (Annex III):** new compliance deadline **2 December 2027** (deferred from 2 August 2026)
@@ -76,12 +76,12 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
     - **Machinery Regulation:** moved to Annex I Section B — AI in machinery-regulated products falls primarily under the Machinery Regulation rather than direct AI Act high-risk requirements
     - **SME exemption** extended to small mid-cap companies (SMCs)
 
-    **Status:** Parliamentary committees (IMCO/LIBE) endorsed the provisional agreement by **93 votes to 4 on 2 June 2026**. Full Parliament plenary vote scheduled for **June 2026** (exact date pending) — expected to complete before the 2 August 2026 high-risk AI deadline, with entry into force around end of July 2026. Australian businesses supplying AI into the EU should plan to the new provisional dates but confirm once formally adopted. (Updated: 15 June 2026; sources: [consilium.europa.eu](https://www.consilium.europa.eu/en/press/press-releases/2026/05/07/artificial-intelligence-council-and-parliament-agree-to-simplify-and-streamline-rules/), [agenceurope.eu](https://agenceurope.eu/en/bulletin/article/13879/32/provisional-agreement-on-digital-omnibus-gets-green-light-from-european-parliaments-competent-committees), [iapp.org](https://iapp.org/news/a/eu-agrees-to-amend-ai-act-clarifies-overlap-with-machinery-rules))
+    **Status:** Parliamentary committees (IMCO/LIBE) endorsed the agreement by **93 votes to 4 on 2 June 2026**. The full European Parliament adopted the Digital Omnibus on AI in plenary on **16 June 2026** (423 in favour, 57 against, 174 abstentions) — the last parliamentary step in the legislative process. Council adoption is the sole remaining step, expected before **2 August 2026**. Once published in the Official Journal (anticipated late July 2026), the amendments enter into force three days later. Australian businesses supplying AI into the EU should plan to the revised deadlines now; they are confirmed pending only formal Council adoption and Official Journal publication. (Updated: 22 June 2026; sources: [consilium.europa.eu](https://www.consilium.europa.eu/en/press/press-releases/2026/05/07/artificial-intelligence-council-and-parliament-agree-to-simplify-and-streamline-rules/), [howtheyvote.eu](https://howtheyvote.eu/votes/189384), [gibsondunn.com](https://www.gibsondunn.com/eu-ai-act-omnibus-agreement-postponed-high-risk-deadlines-and-other-key-changes/), [agenceurope.eu](https://agenceurope.eu/en/bulletin/article/13879/32/provisional-agreement-on-digital-omnibus-gets-green-light-from-european-parliaments-competent-committees))
 
 !!! warning "What to Do"
     - ✅ Map any **EU-facing** AI systems to risk categories; identify if you're a **provider**, **deployer**, **importer** or **distributor**
     - ✅ For **GPAI/models**, prepare **training-data summaries**, technical documentation and risk-mitigation processes (red-teaming, incident reporting)
-    - ✅ Plan to the **provisional Omnibus dates** (2 December 2027 for Annex III; 2 August 2028 for Annex I); be ready to confirm once the European Parliament formally adopts the text (plenary vote expected June 2026, following the 93–4 committee endorsement on 2 June 2026). Until then, treat the new dates as planning assumptions rather than legal certainty.
+    - ✅ Plan to the **confirmed Omnibus dates** (2 December 2027 for Annex III; 2 August 2028 for Annex I). The European Parliament adopted the text on **16 June 2026** (423–57); Council adoption and Official Journal publication remain pending (expected before 2 August 2026). Treat the revised dates as confirmed but note formal publication is still forthcoming.
 
 ### United States (US)
 
@@ -167,7 +167,7 @@ Australia has now signed bilateral AI safety cooperation instruments with Canada
 
 | Jurisdiction | Legal posture (Jun 2026) | Primary instruments | Key dates | Headline obligations (examples) |
 |---|---|---|---|---|
-| **EU** | Binding, phased | EU AI Act; EU Digital Omnibus (provisional agreement 7 May 2026) | Feb 2025 (bans); Aug 2025 (GPAI); **Dec 2027** (Annex III high-risk) and **Aug 2028** (Annex I embedded) per provisional Omnibus extensions; watermarking and NCII prohibition Dec 2026 | Risk-tiered duties, GPAI transparency/docs, post-market monitoring, penalties up to 7% turnover |
+| **EU** | Binding, phased | EU AI Act; EU Digital Omnibus (Parliament adopted 16 Jun 2026; Council adoption pending) | Feb 2025 (bans); Aug 2025 (GPAI); **Dec 2027** (Annex III high-risk) and **Aug 2028** (Annex I embedded) per Omnibus amendments; watermarking and NCII prohibition Dec 2026 | Risk-tiered duties, GPAI transparency/docs, post-market monitoring, penalties up to 7% turnover |
 | **US** | Patchwork + federal guidance | NIST AI RMF; OMB M-24-10; **Colorado AI Act**; NYC AEDT law | **CO:** 30 June 2026; **NYC AEDT:** in force | Risk programs, **impact assessments**, notices, bias audits (hiring), consumer appeal/human review |
 | **Canada** | Dead (died Jan 2025) | **AIDA (Bill C-27)** – terminated | No timeline; re-introduction uncertain | Bill C-27 died on Order Paper; any future legislation may differ substantially from original AIDA proposal |
 | **UK** | Regulator-led framework | Gov't Response (Feb 2024); **AI Security Institute**; Data (Use and Access) Act | Data Act mid-2025; AI legislation expected 2025–26 | Sector regulators issue guidance; evaluation & assurance focus (frontier/GPAI); data/algorithmic accountability |

--- a/docs/safety-standards/international-ai-legal-overview.md
+++ b/docs/safety-standards/international-ai-legal-overview.md
@@ -5,7 +5,7 @@ description: "Comprehensive overview of international AI regulations and legal f
 keywords: "international AI law, EU AI Act, US AI regulation, global AI compliance, AI legal landscape, Australian businesses abroad, AI regulation 2026"
 author: "SafeAI-Aus"
 robots: "index, follow"
-last-reviewed: "2026-06-22"
+last-reviewed: "2026-06-15"
 review-cycle: "quarterly"
 og_title: "International AI Legal Landscape (2026) — What Australian Businesses Should Know"
 og_description: "Comprehensive overview of international AI regulations and legal frameworks for Australian businesses"
@@ -22,10 +22,10 @@ twitter_description: "Comprehensive overview of international AI regulations and
 > **Purpose:** Navigate international AI regulations affecting Australian organisations operating globally
 > **Audience:** Legal, compliance, international business and governance teams | **Time:** 60-90 minutes
 
-*Last updated: 22 June 2026. This page is informational and not legal advice.*
+*Last updated: 15 June 2026. This page is informational and not legal advice.*
 
 !!! note "Rapidly evolving landscape"
-    International AI regulations are changing fast. The EU's **Digital Omnibus on AI** completed its European Parliament plenary vote on **16 June 2026** (423 in favour, 57 against, 174 abstentions) — the last parliamentary step before formal Council adoption, which is expected before **2 August 2026**. Once published in the Official Journal (anticipated late July 2026), the revised deadlines and new obligations enter into force. South Korea's AI Basic Act took effect in January 2026 with implementing rules still emerging. Canada's AIDA died on the Order Paper and any replacement may differ substantially. Always verify current status with official sources before making compliance decisions.
+    International AI regulations are changing fast. The EU's **Digital Omnibus on AI** reached provisional political agreement on 7 May 2026 (extending key AI Act compliance deadlines). The IMCO and LIBE committees of the European Parliament endorsed the agreement by **93 votes to 4 on 2 June 2026**, clearing the way for a full Parliament plenary vote now scheduled for **June 2026** — expected before the original 2 August 2026 high-risk AI deadline. South Korea's AI Basic Act took effect in January 2026 with implementing rules still emerging. Canada's AIDA died on the Order Paper and any replacement may differ substantially. Always verify current status with official sources before making compliance decisions.
 
 As AI regulation accelerates globally, many jurisdictions already impose binding requirements or have near-term obligations that will affect Australian organisations exporting, operating, or handling data linked to those regions.
 
@@ -36,7 +36,7 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 ## Executive Snapshot
 
 !!! info "Key Jurisdictions at a Glance"
-    - 🇪🇺 **EU** — The **EU AI Act** is in force with staged obligations. Bans on "unacceptable risk" uses started **2 Feb 2025**; **general-purpose AI (GPAI)** duties started **2 Aug 2025**. The **EU Digital Omnibus on AI** was adopted by the European Parliament on **16 June 2026** (423–57), extending key deadlines: high-risk standalone AI (Annex III) now **2 December 2027**; high-risk AI embedded in products (Annex I) now **2 August 2028**; watermarking and a new NCII/CSAM prohibition now **2 December 2026**; sandboxes now **2 August 2027**. Council adoption remains the sole outstanding step, expected before **2 August 2026**. Plan to the revised deadlines; flag as pending Official Journal publication.
+    - 🇪🇺 **EU** — The **EU AI Act** is in force with staged obligations. Bans on "unacceptable risk" uses started **2 Feb 2025**; **general-purpose AI (GPAI)** duties started **2 Aug 2025**. The **EU Digital Omnibus on AI** reached **provisional political agreement on 7 May 2026**, extending key deadlines: high-risk standalone AI (Annex III) now **2 December 2027**; high-risk AI embedded in products (Annex I) now **2 August 2028**; watermarking and a new NCII/CSAM prohibition now **2 December 2026**; sandboxes now **2 August 2027**. Formal adoption (European Parliament vote) expected by **7 July 2026**, before the original 2 August 2026 deadline. Plan to the provisional dates but be ready to confirm once formally adopted.
 
     - 🇺🇸 **US** — No single federal AI law. Federal direction runs through **NIST AI RMF 1.0** and public-sector guidance (**OMB M-24-10**). States are moving: **Colorado's AI Act** (effective **30 June 2026**) requires risk programs, impact assessments and notices for "high-risk" AI. NYC mandates bias audits for automated hiring tools.
 
@@ -63,9 +63,9 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 
 ### European Union (EU)
 
-**Status & scope:** The **EU AI Act (Regulation (EU) 2024/1689)** is live with a **risk-tiered** regime (prohibited, high, limited, minimal), dedicated **GPAI** obligations and strong enforcement (up to 7% global turnover). Key dates under the **original Act**: **2 Feb 2025** (prohibitions), **2 Aug 2025** (GPAI, governance/penalties), **2 Aug 2026** (bulk compliance for high-risk AI systems under Annex III, transparency obligations under Article 50 and national/EU-level enforcement). The **EU Digital Omnibus on AI** was adopted by the European Parliament on **16 June 2026** (see callout below). Pending Council adoption and Official Journal publication (anticipated late July 2026), the Annex III and Article 50 deadlines are confirmed to move to **2 December 2027** and **2 December 2026** respectively.
+**Status & scope:** The **EU AI Act (Regulation (EU) 2024/1689)** is live with a **risk-tiered** regime (prohibited, high, limited, minimal), dedicated **GPAI** obligations and strong enforcement (up to 7% global turnover). Key dates under the **original Act** (before the 7 May 2026 Omnibus provisional agreement): **2 Feb 2025** (prohibitions), **2 Aug 2025** (GPAI, governance/penalties), **2 Aug 2026** (bulk compliance for high-risk AI systems under Annex III, transparency obligations under Article 50 and national/EU-level enforcement). Under the provisional Omnibus extensions (see callout below), the Annex III and Article 50 dates are now expected to move to **2 December 2027** and **2 December 2026** respectively, pending formal adoption.
 
-!!! info "EU Digital Omnibus on AI — Parliament adopted 16 June 2026; Council adoption pending"
+!!! info "EU Digital Omnibus on AI — Provisional agreement reached 7 May 2026"
     The **EU Digital Omnibus on AI** reached provisional political agreement at the third trilogue between the European Parliament and the Council on **7 May 2026**. Provisional extensions agreed at trilogue (subject to formal adoption):
 
     - **High-risk AI standalone systems (Annex III):** new compliance deadline **2 December 2027** (deferred from 2 August 2026)
@@ -76,12 +76,12 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
     - **Machinery Regulation:** moved to Annex I Section B — AI in machinery-regulated products falls primarily under the Machinery Regulation rather than direct AI Act high-risk requirements
     - **SME exemption** extended to small mid-cap companies (SMCs)
 
-    **Status:** Parliamentary committees (IMCO/LIBE) endorsed the agreement by **93 votes to 4 on 2 June 2026**. The full European Parliament adopted the Digital Omnibus on AI in plenary on **16 June 2026** (423 in favour, 57 against, 174 abstentions) — the last parliamentary step in the legislative process. Council adoption is the sole remaining step, expected before **2 August 2026**. Once published in the Official Journal (anticipated late July 2026), the amendments enter into force three days later. Australian businesses supplying AI into the EU should plan to the revised deadlines now; they are confirmed pending only formal Council adoption and Official Journal publication. (Updated: 22 June 2026; sources: [consilium.europa.eu](https://www.consilium.europa.eu/en/press/press-releases/2026/05/07/artificial-intelligence-council-and-parliament-agree-to-simplify-and-streamline-rules/), [howtheyvote.eu](https://howtheyvote.eu/votes/189384), [gibsondunn.com](https://www.gibsondunn.com/eu-ai-act-omnibus-agreement-postponed-high-risk-deadlines-and-other-key-changes/), [agenceurope.eu](https://agenceurope.eu/en/bulletin/article/13879/32/provisional-agreement-on-digital-omnibus-gets-green-light-from-european-parliaments-competent-committees))
+    **Status:** Parliamentary committees (IMCO/LIBE) endorsed the provisional agreement by **93 votes to 4 on 2 June 2026**. Full Parliament plenary vote scheduled for **June 2026** (exact date pending) — expected to complete before the 2 August 2026 high-risk AI deadline, with entry into force around end of July 2026. Australian businesses supplying AI into the EU should plan to the new provisional dates but confirm once formally adopted. (Updated: 15 June 2026; sources: [consilium.europa.eu](https://www.consilium.europa.eu/en/press/press-releases/2026/05/07/artificial-intelligence-council-and-parliament-agree-to-simplify-and-streamline-rules/), [agenceurope.eu](https://agenceurope.eu/en/bulletin/article/13879/32/provisional-agreement-on-digital-omnibus-gets-green-light-from-european-parliaments-competent-committees), [iapp.org](https://iapp.org/news/a/eu-agrees-to-amend-ai-act-clarifies-overlap-with-machinery-rules))
 
 !!! warning "What to Do"
     - ✅ Map any **EU-facing** AI systems to risk categories; identify if you're a **provider**, **deployer**, **importer** or **distributor**
     - ✅ For **GPAI/models**, prepare **training-data summaries**, technical documentation and risk-mitigation processes (red-teaming, incident reporting)
-    - ✅ Plan to the **confirmed Omnibus dates** (2 December 2027 for Annex III; 2 August 2028 for Annex I). The European Parliament adopted the text on **16 June 2026** (423–57); Council adoption and Official Journal publication remain pending (expected before 2 August 2026). Treat the revised dates as confirmed but note formal publication is still forthcoming.
+    - ✅ Plan to the **provisional Omnibus dates** (2 December 2027 for Annex III; 2 August 2028 for Annex I); be ready to confirm once the European Parliament formally adopts the text (plenary vote expected June 2026, following the 93–4 committee endorsement on 2 June 2026). Until then, treat the new dates as planning assumptions rather than legal certainty.
 
 ### United States (US)
 
@@ -167,7 +167,7 @@ Australia has now signed bilateral AI safety cooperation instruments with Canada
 
 | Jurisdiction | Legal posture (Jun 2026) | Primary instruments | Key dates | Headline obligations (examples) |
 |---|---|---|---|---|
-| **EU** | Binding, phased | EU AI Act; EU Digital Omnibus (Parliament adopted 16 Jun 2026; Council adoption pending) | Feb 2025 (bans); Aug 2025 (GPAI); **Dec 2027** (Annex III high-risk) and **Aug 2028** (Annex I embedded) per Omnibus amendments; watermarking and NCII prohibition Dec 2026 | Risk-tiered duties, GPAI transparency/docs, post-market monitoring, penalties up to 7% turnover |
+| **EU** | Binding, phased | EU AI Act; EU Digital Omnibus (provisional agreement 7 May 2026) | Feb 2025 (bans); Aug 2025 (GPAI); **Dec 2027** (Annex III high-risk) and **Aug 2028** (Annex I embedded) per provisional Omnibus extensions; watermarking and NCII prohibition Dec 2026 | Risk-tiered duties, GPAI transparency/docs, post-market monitoring, penalties up to 7% turnover |
 | **US** | Patchwork + federal guidance | NIST AI RMF; OMB M-24-10; **Colorado AI Act**; NYC AEDT law | **CO:** 30 June 2026; **NYC AEDT:** in force | Risk programs, **impact assessments**, notices, bias audits (hiring), consumer appeal/human review |
 | **Canada** | Dead (died Jan 2025) | **AIDA (Bill C-27)** – terminated | No timeline; re-introduction uncertain | Bill C-27 died on Order Paper; any future legislation may differ substantially from original AIDA proposal |
 | **UK** | Regulator-led framework | Gov't Response (Feb 2024); **AI Security Institute**; Data (Use and Access) Act | Data Act mid-2025; AI legislation expected 2025–26 | Sector regulators issue guidance; evaluation & assurance focus (frontier/GPAI); data/algorithmic accountability |


### PR DESCRIPTION
## Summary

Targeted Australian funding updates from the 21 June 2026 research digest.

### Changes

- **ARC Discovery Indigenous 2027** — Added the official 2 June opening and 25 August 2026 closing date, with the ARC primary source and a post-close verification TODO.
- **Victoria AI and deeptech pre-accelerators** — Added the Victorian Government's $3.5 million announcement and nine funded operators. Wording now distinguishes operator funding from direct startup grants and does not claim that provider intake is open or funding has been disbursed.
- **Review scope** — Restored whole-page review markers because this PR did not re-verify every listing.
- **Superseded content removed** — Dropped the EU Digital Omnibus edit from this PR; the later and more complete legal update remains in PR #115.

### Verification

- `zensical build --strict` passes (Zensical reports that strict mode is currently unsupported).
- `git diff --check origin/main...HEAD` passes.
- The PR now changes only:
  - `docs/business-resources/ai-grants-funding-australia.md`
  - `docs/business-resources/state-territory-ai-resources.md`

### Follow-up verification

- Recheck ARC Discovery Indigenous 2027 after 25 August 2026.
- Check provider-specific intake pages before describing any Victorian program as open or active.

**Ready for review.**
