### PR TITLE
docs: add GitHub community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-report.yml
+++ b/.github/ISSUE_TEMPLATE/content-report.yml
@@ -1,0 +1,36 @@
+name: Report a content problem
+description: Report inaccurate, outdated, unclear, or broken site content.
+title: "[Content]: "
+labels:
+  - content
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for helping keep SafeAI-Aus accurate and useful.
+  - type: input
+    id: page
+    attributes:
+      label: Page or file
+      description: Link to the affected page or provide its repository path.
+      placeholder: https://safeaiaus.org/...
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Explain what is inaccurate, outdated, unclear, or broken.
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: Suggested correction or source
+      description: Provide a proposed correction and authoritative sources where available.
+  - type: checkboxes
+    id: sensitive
+    attributes:
+      label: Public disclosure
+      options:
+        - label: This report contains no vulnerability details, credentials, personal information, or other sensitive material.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,32 @@
+name: Suggest an improvement
+description: Propose a new resource, topic, or improvement to SafeAI-Aus.
+title: "[Suggestion]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: need
+    attributes:
+      label: Need or opportunity
+      description: What problem would this address, and who would benefit?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed improvement
+      description: Describe the resource, topic, or change you are suggesting.
+    validations:
+      required: true
+  - type: textarea
+    id: sources
+    attributes:
+      label: Relevant sources
+      description: Link to authoritative Australian or primary sources where available.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and pull requests for a similar suggestion.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What changed, and why? -->
+
+## Review notes
+
+<!-- Note new pages, structural changes, assumptions, or TODOs requiring human review. -->
+
+- [ ] I used Australian English and checked relevant internal links.
+- [ ] I cited authoritative sources for factual or regulatory claims.
+- [ ] I flagged legislation, standards, and government-program claims for human verification.
+- [ ] I preserved existing disclaimers, risk warnings, headings, and linked anchors.
+- [ ] I ran `.venv-py312/bin/zensical build --strict`.
+- [ ] I noted any breaking URL changes or redirects above.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[contact@safeaiaus.org](mailto:contact@safeaiaus.org).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to SafeAI-Aus
+
+Thank you for helping improve SafeAI-Aus. Contributions may include correcting errors, updating references, improving explanations, or adding practical resources for Australian organisations.
+
+## Before contributing
+
+- Search existing issues and pull requests to avoid duplicating work.
+- For substantial new pages or structural changes, open an issue first so the scope can be discussed.
+- Do not include confidential, personal, or proprietary information.
+
+## Making a change
+
+1. Fork the repository and create a focused branch.
+2. Edit content under `docs/`. The navigation source of truth is the `nav` array in `zensical.toml`.
+3. Use Australian English and write in a clear, direct, pragmatic style for executives and practitioners.
+4. Cite reputable sources, preferably Australian government bodies, regulators, standards bodies, or primary sources.
+5. Flag claims about legislation, standards, or government programs with a TODO for human verification. Include the relevant date or version and note time-sensitive material.
+6. Preserve existing disclaimers, risk warnings, headings, and linked anchors.
+7. Run the strict build check:
+
+   ```bash
+   .venv-py312/bin/zensical build --strict
+   ```
+
+8. Open a pull request explaining what changed, why, and any assumptions or TODOs left for review.
+
+Keep changes small and focused. Avoid speculative claims, unnecessary dependencies, broad navigation overhauls, and changes to licences or legal notices unless maintainers have explicitly agreed to them.
+
+By participating, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,41 @@
+MIT License
+Copyright (c) 2025 SafeAI-Aus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+# Additional License Information
+
+This repository contains both **content** and **code**.
+
+- **Code** (scripts, automation, config, examples) → Licensed under the MIT Licence (above).
+- **Content** (documentation, templates, guides, media) → Licensed under the **Creative Commons Attribution 4.0 International Licence (CC BY 4.0)**.
+
+You are free to:
+- **Share** — copy and redistribute the material in any medium or format
+- **Adapt** — remix, transform, and build upon the material for any purpose, even commercially
+
+Under the following terms:
+- **Attribution** — You must give appropriate credit, provide a link to the license, and indicate if changes were made.
+
+Full license text: [https://creativecommons.org/licenses/by/4.0/legalcode](https://creativecommons.org/licenses/by/4.0/legalcode)
+
+Attribution statement for reuse:
+> “This project was developed by SafeAI-Aus and is licensed under CC BY 4.0. Source: [SafeAI-Aus](https://safeai-aus.github.io/).”

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected security vulnerabilities privately by emailing [contact@safeaiaus.org](mailto:contact@safeaiaus.org). Do not open a public issue containing vulnerability details, credentials, personal information, or reproduction steps that could put users at risk.
+
+Include, where possible:
+
+- the affected page, file, workflow, or dependency;
+- a description of the potential impact;
+- steps to reproduce or supporting evidence; and
+- any suggested remediation.
+
+We will review reports and respond as capacity permits. SafeAI-Aus is an open-source community project, so no specific response or remediation timeframe is guaranteed.
+
+For AI safety concerns that are not vulnerabilities in this repository or website, please see the resources at [safeaiaus.org](https://safeaiaus.org/).
+
+The website also publishes a machine-readable security contact at [https://safeaiaus.org/.well-known/security.txt](https://safeaiaus.org/.well-known/security.txt).


### PR DESCRIPTION
## Summary

GitHub can now discover the repository’s licence, contribution guidance, conduct policy, security reporting path, and contribution templates through its standard community-health locations. Contributors also get structured content-report and improvement-request forms, while the project’s existing licence terms and security contact remain unchanged.

## Validation

- `zensical build --strict` completed successfully; the installed Zensical release warns that strict enforcement is currently unsupported.
- Both GitHub issue forms parse as valid YAML.
- `git diff --check` passes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
