### PR TITLE
fix: Monthly SEO fixes 2026-07-12

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -102,4 +102,4 @@ Agents can poll `/updates.json` to discover what has changed since their last vi
 - GitHub: github.com/safeai-aus/safeai-aus.github.io
 
 ---
-Last updated: 2026-06-28
+Last updated: 2026-07-12

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@ license = "CC BY 4.0"
 repo = "https://github.com/safeai-aus/safeai-aus.github.io"
 website = "https://safeaiaus.org"
 policy-version = "1.2"
-last-updated = "2026-06-28"
+last-updated = "2026-07-12"
 changelog = "https://safeaiaus.org/updates.json"
 full-summary = "https://safeaiaus.org/llms-full.txt"
 


### PR DESCRIPTION
Automated fixes from the monthly SEO audit — 12 July 2026.

## Fixes applied

- **llms.txt** — `last-updated` bumped from `2026-06-28` to `2026-07-12`. PRs #113 and #115 merged today added content (EU AI Act entry into force, Victoria pre-accelerators, UTP Act royal assent, DTA CAIO milestone); the agent-readable date was stale.
- **llms-full.txt** — `Last updated` bumped from `2026-06-28` to `2026-07-12` for the same reason.

Build validated clean (34 pages, no errors) after changes.

## Issues reported (not auto-fixed)

1. **Schema: HowTo frontmatter missing from 2 governance templates** — requires content expertise to write step sequences:
   - `governance-templates/ai-readiness-checklist.md`
   - `governance-templates/ai-vendor-evaluation-checklist.md`

2. **Content freshness overdue (162 days, quarterly threshold 100 days)** — requires human content review:
   - `business-resources/ai-learning-development-directory.md` (last-reviewed: 2026-01-31)
   - `resources/australian-ai-community.md` (last-reviewed: 2026-01-31)

3. **External link verification** — outbound HTTP blocked by cloud proxy. Priority manual spot-check: `industry.gov.au`, `digital.gov.au`, `dta.gov.au`, `oaic.gov.au` (historically volatile URLs).

4. **Sitemap `<lastmod>` dates absent** — Zensical does not populate these. Consider post-processing in `deploy.yml` via `git log` per page.

5. **Contextual orphan pages** — reachable via nav sidebar but no in-body markdown links point to them. Lower priority given nav-driven architecture:
   - `business-resources/agent-readable-resources.md`
   - `resources/australian-ai-community.md`
   - `business-resources/ai-governance-faq.md`

Source: agent-engine/maintenance/seo-report-2026-07-12.md

---
_Generated by [Claude Code](https://claude.ai/code/session_013KF4LAfY95tLFgGi62BTVQ)_