### PR TITLE
Content update — 26 July 2026 digest

### DIFF
--- a/docs/business-resources/ai-grants-funding-australia.md
+++ b/docs/business-resources/ai-grants-funding-australia.md
@@ -3,7 +3,7 @@ icon: lucide/dollar-sign
 title: "AI Grants & Funding for Australian Businesses"
 description: "Australian AI grants, funding programs and financial support for businesses adopting AI responsibly, including federal, state and industry opportunities."
 keywords: "AI grants Australia, AI funding Australia, AI business grants, Australian AI funding, AI government grants, AI business support, AI investment Australia, AI startup funding"
-last-reviewed: "2026-07-22"
+last-reviewed: "2026-07-27"
 review-cycle: "quarterly"
 og_description: "Comprehensive guide to AI grants, funding programs and financial support for Australian businesses"
 og_type: "article"
@@ -18,7 +18,7 @@ og_type: "article"
     - **CRC Program Round 27** Stage 1 closed 29 April 2026. **Stage 2 is under way from July to September 2026 for invited applicants only**. Stage 2 outcomes are expected in early 2027.
     - **CRC-P Round 19 (AI Accelerator stream, $20M)** closed 12 May 2026 at 5:00 PM AEST. Outcomes now expected October 2026 (delayed from August due to high application volume).
 
-    The next AI Accelerator full CRC opportunity (Round 28) is expected in 2027.
+    **CRC Round 28 (AI Accelerator, ~$50 million)** was announced on 5 March 2026 and is expected to open in 2027 for medium-to-long-term industry-led AI research collaborations. See the full entry below.
 
 <!-- TODO: Human verification required before publication: confirm CRC Round 27 Stage 2 dates and invitation-only status on business.gov.au. -->
 
@@ -122,12 +122,19 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 - **Status:** Stage 1 **closed 29 April 2026**. The published timetable lists Stage 2 from **July to September 2026**, with outcomes expected in early 2027. Stage 2 is invitation-only: the Minister invites selected Stage 1 applicants to submit a Stage 2 application and attend an interview.
 - ➡️ [CRC Program details](https://business.gov.au/grants-and-programs/cooperative-research-centres-crc-grants)
 
-### AI Accelerator CRC (Future)
+### Cooperative Research Centres (CRC) Program — Round 28 (AI Accelerator)
 
-- Approximately **$50 million** planned for a dedicated AI Cooperative Research Centre.
-- Part of the broader AI Accelerator initiative to drive industry-led AI research at scale.
-- CRC Round 28 expected to open in **2027**.
-- ➡️ [AI Accelerator initiative](https://www.industry.gov.au/news/ai-accelerator-initiative-kicks-funding-industry-led-research)
+- Approximately **$50 million** available to support at least one dedicated AI-focused Cooperative Research Centre (CRC).
+- Announced **5 March 2026** as part of the broader AI Accelerator initiative.
+- **Status:** Not yet open. Round 28 is expected to open in **2027**; the exact date has not been published.
+- **AI priority areas for CRC Round 28:**
+    1. Building broad AI capability in Australia — core AI technologies applicable across multiple sectors
+    2. Applying AI to real-world challenges in healthcare, agriculture, resources, energy and advanced manufacturing
+    3. Supporting Australian AI businesses to innovate, scale and compete globally, including developing bespoke Australian AI models
+    4. Developing AI capability across Australia's industry base more broadly
+- **Program structure:** CRC grants support medium-to-long-term collaborations of up to 10 years, industry-led, requiring at least three industry organisations and two research organisations. Unlike CRC-P short-term project grants, CRCs are long-duration partnerships.
+- Round 28 is also open to applications from other sectors and disciplines beyond AI.
+- ➡️ [AI Accelerator CRC announcement (industry.gov.au)](https://www.industry.gov.au/news/ai-accelerator-round-drive-commercialisation-across-australia) | [CRC Program details (business.gov.au)](https://business.gov.au/grants-and-programs/cooperative-research-centres-crc-grants)
 
 ---
 
@@ -243,7 +250,7 @@ AI is reshaping industries across Australia. To support businesses in responsibl
 | CSIRO-NSF AI Collaboration | International Grant | $9.6m (2023) | Responsible AI research | Active |
 | CRC-P Round 19 (AI Stream) | Federal Grant | $100k–$3m ($20m pool) | Collaborative AI research | Closed 12 May 2026; outcomes expected Oct 2026 |
 | CRC Program Round 27 | Federal Grant | $2–5m | Industry-research consortia | Stage 2 under way Jul–Sep 2026 (invited applicants only); outcomes expected early 2027 |
-| AI Accelerator CRC | Federal (Future) | ~$50m | Dedicated AI CRC | Expected 2027 |
+| CRC Round 28 (AI Accelerator, ~$50M) | Federal (Future) | ~$50m | Dedicated AI CRC (announced 5 Mar 2026; 4 AI priority areas) | Opens 2027 — not yet open |
 | AWS AI Accelerator | Corporate | US$230m pool | Generative AI startups | Active |
 | NRFC | Co‑investment fund | $550m+ | Large-scale ventures | Active |
 | Fearless Innovator Grant | Micro‑grant | $100k | Female founders in AI | Completed (2024) |

--- a/docs/business-resources/state-territory-ai-resources.md
+++ b/docs/business-resources/state-territory-ai-resources.md
@@ -3,7 +3,7 @@ icon: lucide/map-pin
 title: "Australian Government AI Resources"
 description: "Official AI strategies, policies, assurance frameworks and statutory guidance from Australian federal, state and territory governments."
 keywords: "Australian government AI resources, federal AI policy, state AI policies, territory AI policies, government AI strategies, NAIC, OAIC, DTA, NSW AI policy, Victoria AI guidance, Queensland AI framework, SA AI resources, WA AI policy, Tasmania AI guidance, ACT AI policy, NT AI framework"
-last-reviewed: "2026-07-22"
+last-reviewed: "2026-07-27"
 review-cycle: "quarterly"
 og_description: "Comprehensive guide to AI resources published by Australian federal, state and territory governments"
 og_type: "article"
@@ -101,6 +101,28 @@ For a detailed overview of Australian AI legislation, see our [AI & Australian L
     A featured program is **VICTOR:AI** — an eight-week cohort for AI-native startups offering access to AI tools, co-working space and milestone-based grants. This initiative is consistent with Victoria's **AI Mission Statement** (announced 30 January 2026), positioning Victoria as a national AI leader.
 
     Provider intake arrangements and timing vary. The announcement did not specify which programs were accepting applications or confirm that funding had been disbursed. See [djsir.vic.gov.au](https://djsir.vic.gov.au/news-and-articles/victoria-backs-the-next-generation-of-ai-and-deeptech-startups) for the provider list and announced program details (accessed 21 June 2026).
+
+!!! info "Victoria — Workplace Surveillance and AI Laws Announced (July 2026, pre-legislative)"
+    The Federal Government and the Victorian Government jointly announced plans for workplace surveillance legislation addressing AI-enabled monitoring. Neither bill had been introduced to parliament as of 26 July 2026. Victoria's state election is scheduled for November 2026.
+
+    **Proposed protections (Victorian legislation; federal scope to be confirmed):**
+
+    - Workers' right to know when they are being monitored
+    - Employer consultation obligations before introducing any surveillance or AI management tools
+    - Biometric data collection permitted only where no less intrusive option is available
+    - Prohibition on using biometrics to assess employees' emotions without a legitimate operational reason
+    - Prohibition on AI tracking personal characteristics including bathroom breaks, pregnancy, disability and physical conditions
+    - Protection against surveillance data being used for discrimination (race, gender, sexuality, religion)
+
+    Organisations using AI scheduling, biometric monitoring or algorithmic management tools should monitor Victorian and federal parliament for bill introduction. (Sources: ohsrep.org.au, ia.acs.org.au, smbtech.au, ohsalert.com.au, accessed 26 July 2026)
+
+!!! info "Victoria — Online Safety and AI Platform Laws Announced (19 July 2026, pre-legislative)"
+    The Victorian Government announced plans for new laws targeting online anonymity and AI platform harms. Laws are not yet drafted; targeted consultation with VCAT and the courts is planned. Key proposed elements:
+
+    - **"Demasking" powers:** The Victorian Civil and Administrative Tribunal (VCAT) would be granted powers to order social media and AI platforms to reveal the identity of anonymous accounts accused of online vilification.
+    - **Lower harm threshold for minors:** The current 10% permanent psychiatric impairment threshold for negligence claims against AI or social media platforms will be removed for claims brought on behalf of minors. Extension to adults is under consideration during drafting.
+
+    Monitor the Victorian Parliament for bill introduction. (Sources: capitalbrief.com, theindiansun.com.au, theconversation.com, accessed 26 July 2026)
 
 ---
 

--- a/docs/safety-standards/ai-australian-legislation.md
+++ b/docs/safety-standards/ai-australian-legislation.md
@@ -3,7 +3,7 @@ icon: lucide/flag
 title: "Current Legal Landscape for AI in Australia"
 description: "Overview of Australian laws relevant to AI adoption, including privacy, consumer protection, anti-discrimination and intellectual property."
 keywords: "AI legislation Australia, Australian AI law, AI privacy law, AI consumer law, AI discrimination law, AI intellectual property, AI legal compliance, Australian AI regulations, AI legal framework"
-last-reviewed: "2026-07-22"
+last-reviewed: "2026-07-27"
 review-cycle: "quarterly"
 og_description: "Comprehensive overview of current legislation applicable to AI adoption in Australian business"
 og_type: "article"
@@ -169,6 +169,12 @@ Australia's **IP laws**—covering copyright, patents, trademarks and design rig
 
 - ⚖️ **Consumer law — Competition and Consumer Amendment (Unfair Trading Practices) Act 2026 (assented 6 July 2026; commences 1 July 2027)**
   The Act received Royal Assent on 6 July 2026. Its technology-neutral prohibition may capture AI-enabled dark patterns and algorithmic manipulation where the statutory test is met. See the Australian Consumer Law section above for details. The Treasury review also found the existing ACL "fit for purpose" for AI; no broader dedicated AI consumer legislation is expected in the near term.
+
+- 🏢 **Federal and Victorian workplace surveillance and AI laws — announced July 2026 (pre-legislative)**
+  The Federal Government and the Victorian Government jointly announced plans for workplace surveillance legislation that addresses AI-enabled monitoring. Neither bill had been introduced to parliament as of 26 July 2026. Victoria's state election is scheduled for November 2026, creating a timing constraint. Proposed protections (Victorian legislation; federal scope to be confirmed) include: the right to know when being monitored; employer consultation obligations before introducing surveillance or AI management tools; biometric data collection only where no less intrusive option exists; prohibition on using biometrics to assess employees' emotions without a legitimate operational reason (e.g. fatigue monitoring); prohibition on AI tracking personal characteristics including bathroom breaks, pregnancy, disability and physical conditions; and protection against surveillance data being used for discrimination (race, gender, sexuality, religion). Organisations using AI scheduling, biometric monitoring or algorithmic management tools should monitor Victorian and federal parliament for bill introduction. (Sources: ohsrep.org.au, ia.acs.org.au, smbtech.au, ohsalert.com.au, accessed 26 July 2026)
+
+- 🏛️ **Victoria — Online safety and AI platform laws — announced 19 July 2026 (pre-legislative)**
+  The Victorian Government separately announced plans for laws targeting online anonymity and AI platform harms. Key proposed elements: "demasking" powers for the Victorian Civil and Administrative Tribunal (VCAT) to order social media and AI platforms to reveal the identity of anonymous accounts accused of online vilification; removal of the 10% permanent psychiatric impairment threshold for negligence claims brought on behalf of minors against AI or social media platforms (extension to adults is under consideration during drafting). Laws are not yet drafted; targeted consultation with VCAT, the courts and other stakeholders is planned. Timeline to introduction to parliament has not been confirmed. Monitor the Victorian Parliament for bill introduction. (Sources: capitalbrief.com, theindiansun.com.au, theconversation.com, startupdaily.net, accessed 26 July 2026)
 
 !!! info "Government Policy and Guidance"
     For coverage of the National AI Plan, AI Safety Institute, DTA mandatory requirements, Senate Committee response and other government policy developments, see [Australian Government AI Policy and Frameworks](ai-government-policy-frameworks.md).

--- a/docs/safety-standards/international-ai-legal-overview.md
+++ b/docs/safety-standards/international-ai-legal-overview.md
@@ -3,7 +3,7 @@ icon: lucide/globe
 title: "International AI Legal Landscape (2026)"
 description: "Comprehensive overview of international AI regulations and legal frameworks that Australian businesses need to understand for global operations and compliance."
 keywords: "international AI law, EU AI Act, US AI regulation, global AI compliance, AI legal landscape, Australian businesses abroad, AI regulation 2026"
-last-reviewed: "2026-07-06"
+last-reviewed: "2026-07-27"
 review-cycle: "quarterly"
 og_description: "Comprehensive overview of international AI regulations and legal frameworks for Australian businesses"
 og_type: "article"
@@ -17,7 +17,7 @@ og_type: "article"
 *This page is informational and not legal advice.*
 
 !!! note "Rapidly evolving landscape"
-    International AI regulations are changing fast. The European Parliament adopted the **Digital Omnibus on AI** on **16 June 2026** (423 to 57, 174 abstentions), followed by the Council of the EU on **29 June 2026**. Official Journal publication and entry into force remain pending; the revised high-risk AI dates have been adopted but are not yet legally effective. South Korea's AI Basic Act took effect in January 2026 with implementing rules still emerging. Canada's AIDA died on the Order Paper and any replacement may differ substantially. Always verify current status with official sources before making compliance decisions.
+    International AI regulations are changing fast. **Regulation (EU) 2026/1744** — the Digital Omnibus on AI — was published in the Official Journal of the European Union on **24 July 2026** and entered into force on **27 July 2026**. The revised high-risk AI compliance deadlines are now legally effective: standalone Annex III systems move to **2 December 2027** and Annex I embedded systems to **2 August 2028**. South Korea's AI Basic Act took effect in January 2026 with implementing rules still emerging. Canada's AIDA died on the Order Paper and any replacement may differ substantially. Always verify current status with official sources before making compliance decisions.
 
 As AI regulation accelerates globally, many jurisdictions already impose binding requirements or have near-term obligations that will affect Australian organisations exporting, operating, or handling data linked to those regions.
 
@@ -28,7 +28,7 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 ## Executive Snapshot
 
 !!! info "Key Jurisdictions at a Glance"
-    - 🇪🇺 **EU** — The **EU AI Act** is in force with staged obligations. Bans on "unacceptable risk" uses started **2 Feb 2025**; **general-purpose AI (GPAI)** duties started **2 Aug 2025**. Parliament adopted the **EU Digital Omnibus on AI** on **16 June 2026** (423–57, 174 abstentions), followed by the Council on **29 June 2026**. Official Journal publication and entry into force remain pending. Once the Omnibus enters into force, the scheduled dates include **2 December 2027** for high-risk standalone AI (Annex III), **2 August 2028** for high-risk AI embedded in products (Annex I), **2 December 2026** for watermarking and a new NCII/CSAM prohibition, and **2 August 2027** for sandboxes.
+    - 🇪🇺 **EU** — The **EU AI Act** is in force with staged obligations. Bans on "unacceptable risk" uses started **2 Feb 2025**; **general-purpose AI (GPAI)** duties started **2 Aug 2025**. **Regulation (EU) 2026/1744** (the Digital Omnibus on AI) was published in the Official Journal on **24 July 2026** and entered into force on **27 July 2026**. Confirmed compliance deadlines: **2 December 2027** for high-risk standalone AI (Annex III), **2 August 2028** for high-risk AI embedded in regulated products (Annex I), **2 December 2026** for Article 50 transparency obligations and a new NCII/CSAM prohibition, and **2 August 2027** for national AI regulatory sandboxes.
 
     - 🇺🇸 **US** — No single federal AI law. Federal direction runs through **NIST AI RMF 1.0** and public-sector guidance (**OMB M-24-10**). States are moving: **Colorado's AI Act** (effective **30 June 2026**) requires risk programs, impact assessments and notices for "high-risk" AI. NYC mandates bias audits for automated hiring tools.
 
@@ -55,27 +55,29 @@ Below is a practical snapshot of the US, Canada, EU, UK, Japan, South Korea, Sin
 
 ### European Union (EU)
 
-**Status & scope:** The **EU AI Act (Regulation (EU) 2024/1689)** is live with a **risk-tiered** regime (prohibited, high, limited, minimal), dedicated **GPAI** obligations and strong enforcement (up to 7% global turnover). Key dates under the **original Act** include **2 Feb 2025** (prohibitions), **2 Aug 2025** (GPAI, governance/penalties) and **2 Aug 2026** (the original high-risk AI deadline). Parliament adopted the **Digital Omnibus on AI** on 16 June 2026, followed by the Council on 29 June 2026. The Omnibus schedules the Annex III deadline for **2 December 2027** and the Article 50 watermarking date for **2 December 2026**, but these amendments are not legally effective until the regulation is published in the Official Journal and enters into force.
+**Status & scope:** The **EU AI Act (Regulation (EU) 2024/1689)** is live with a **risk-tiered** regime (prohibited, high, limited, minimal), dedicated **GPAI** obligations and strong enforcement (up to 7% global turnover). Key dates under the **original Act** include **2 Feb 2025** (prohibitions), **2 Aug 2025** (GPAI, governance/penalties) and **2 Aug 2026** (original high-risk AI deadline, now deferred by the Omnibus). **Regulation (EU) 2026/1744** — the Digital Omnibus on AI — was published in the Official Journal on **24 July 2026** and entered into force on **27 July 2026**, making its revised compliance dates legally effective.
 
-!!! info "EU Digital Omnibus on AI — Adopted; entry into force pending"
-    The European Parliament adopted the **EU Digital Omnibus on AI** on **16 June 2026** (423 to 57, 174 abstentions), followed by formal adoption by the Council of the EU on **29 June 2026**. Publication in the Official Journal remains pending. The Omnibus will enter into force three days after publication; until then, its amended dates are adopted and scheduled rather than legally effective.
+!!! info "EU Digital Omnibus on AI — Regulation (EU) 2026/1744 — Now in Force (27 July 2026)"
+    **Regulation (EU) 2026/1744** was published in the Official Journal of the European Union (L series) on **24 July 2026** and entered into force on **27 July 2026**. Legislative history: Parliament adopted 16 June 2026 → Council adopted 29 June 2026 → Signed 8 July 2026 → OJ published 24 July 2026 → In force 27 July 2026.
 
-    Adopted amendments scheduled to apply after entry into force include:
+    **Confirmed compliance deadlines (now legally effective):**
 
-    - **High-risk AI standalone systems (Annex III):** new compliance deadline **2 December 2027** (deferred from 2 August 2026)
-    - **High-risk AI embedded in regulated products (Annex I):** new compliance deadline **2 August 2028**
-    - **Article 50 watermarking obligations:** now apply from **2 December 2026** (extended from 2 August 2026)
-    - **New Article 5 prohibition:** AI systems generating non-consensual intimate imagery (NCII) and child sexual abuse material (CSAM), including "nudifier" tools — compliance required by **2 December 2026**
+    - **High-risk AI standalone systems (Annex III):** new deadline **2 December 2027** (deferred from 2 August 2026). Applies to biometric identification, critical infrastructure, employment, credit and public services AI.
+    - **High-risk AI embedded in regulated products (Annex I):** new deadline **2 August 2028**
+    - **Article 50 transparency obligations** (AI systems interacting with natural persons must disclose the AI nature of the interaction): apply from **2 August 2026** — unchanged by the Omnibus
+    - **New Article 5 prohibition** (new prohibited practices effective **2 December 2026**): AI systems generating non-consensual intimate imagery (NCII/"nudification" tools) and AI systems generating child sexual abuse material (CSAM)
     - **AI regulatory sandboxes (national-level):** now **2 August 2027**
-    - **Machinery Regulation:** moved to Annex I Section B — AI in machinery-regulated products falls primarily under the Machinery Regulation rather than direct AI Act high-risk requirements
-    - **SME exemption** extended to small mid-cap companies (SMCs)
+    - **Machinery Regulation amendment:** AI in machinery-regulated products falls primarily under the Machinery Regulation (Annex I Section B) rather than direct AI Act high-risk requirements
 
-    Australian businesses supplying AI into the EU should prepare for the adopted dates while monitoring Official Journal publication and the exact entry-into-force date. (Updated: 6 July 2026; sources: [Council of the EU, 29 June 2026](https://www.consilium.europa.eu/en/press/press-releases/2026/06/29/artificial-intelligence-council-gives-final-green-light-to-simplify-and-streamline-rules/); [European Parliament, 16 June 2026](https://www.europarl.europa.eu/news/en/press-room/20260611IPR45207/ai-act-ep-approves-simplification-measures-and-nudifier-app-ban))
+    **Other key changes:** SME exemption extended to small mid-cap companies (SMCs); Basic Aviation Regulation amended to reduce legal uncertainty and align implementation timelines with harmonised standards.
+
+    Australian businesses supplying AI into the EU should now treat the Omnibus deadlines as legally binding. (Sources: nicfab.eu, modulos.ai, eulawlive.com, gibsondunn.com, freshfields.com — all accessed 26 July 2026; [Council of the EU, 29 June 2026](https://www.consilium.europa.eu/en/press/press-releases/2026/06/29/artificial-intelligence-council-gives-final-green-light-to-simplify-and-streamline-rules/); [European Parliament, 16 June 2026](https://www.europarl.europa.eu/news/en/press-room/20260611IPR45207/ai-act-ep-approves-simplification-measures-and-nudifier-app-ban). Updated: 27 July 2026.)
 
 !!! warning "What to Do"
     - ✅ Map any **EU-facing** AI systems to risk categories; identify if you're a **provider**, **deployer**, **importer** or **distributor**
     - ✅ For **GPAI/models**, prepare **training-data summaries**, technical documentation and risk-mitigation processes (red-teaming, incident reporting)
-    - ✅ Prepare for the **adopted Omnibus dates** (2 December 2027 for Annex III; 2 August 2028 for Annex I), while monitoring Official Journal publication and entry into force before treating them as legally effective.
+    - ✅ The **Omnibus deadlines are now law**: plan for **2 December 2027** (Annex III standalone high-risk AI) and **2 August 2028** (Annex I embedded high-risk AI). Note that **Article 50 transparency obligations apply from 2 August 2026** as originally scheduled.
+    - ✅ If you develop or operate AI systems that could generate NCII or CSAM, these become prohibited practices from **2 December 2026**.
 
 ### United States (US)
 
@@ -161,7 +163,7 @@ Australia has now signed bilateral AI safety cooperation instruments with Canada
 
 | Jurisdiction | Legal posture (July 2026) | Primary instruments | Key dates | Headline obligations (examples) |
 |---|---|---|---|---|
-| **EU** | Binding, phased | EU AI Act; EU Digital Omnibus (adopted by Parliament 16 Jun 2026 and Council 29 Jun 2026; entry into force pending) | Feb 2025 (bans); Aug 2025 (GPAI); adopted Omnibus schedule: **Dec 2027** (Annex III high-risk), **Aug 2028** (Annex I embedded), watermarking and NCII prohibition Dec 2026; OJ publication pending | Risk-tiered duties, GPAI transparency/docs, post-market monitoring, penalties up to 7% turnover |
+| **EU** | Binding, phased | EU AI Act (Reg. 2024/1689); **Regulation (EU) 2026/1744** Digital Omnibus on AI (in force 27 Jul 2026) | Feb 2025 (bans); Aug 2025 (GPAI); **2 Aug 2026** (Art. 50 transparency); **2 Dec 2026** (NCII/CSAM prohibition); **2 Dec 2027** (Annex III high-risk standalone); **2 Aug 2028** (Annex I embedded) | Risk-tiered duties, GPAI transparency/docs, post-market monitoring, penalties up to 7% turnover |
 | **US** | Patchwork + federal guidance | NIST AI RMF; OMB M-24-10; **Colorado AI Act**; NYC AEDT law | **CO:** 30 June 2026; **NYC AEDT:** in force | Risk programs, **impact assessments**, notices, bias audits (hiring), consumer appeal/human review |
 | **Canada** | Dead (died Jan 2025) | **AIDA (Bill C-27)** – terminated | No timeline; re-introduction uncertain | Bill C-27 died on Order Paper; any future legislation may differ substantially from original AIDA proposal |
 | **UK** | Regulator-led framework | Gov't Response (Feb 2024); **AI Security Institute**; Data (Use and Access) Act | Data Act mid-2025; AI legislation expected 2025–26 | Sector regulators issue guidance; evaluation & assurance focus (frontier/GPAI); data/algorithmic accountability |


### PR DESCRIPTION
## Summary

Content updates based on the weekly researcher digest (26 July 2026).

### Changes made

- **`docs/safety-standards/international-ai-legal-overview.md` (Critical):** Regulation (EU) 2026/1744 — the Digital Omnibus on AI — published in the Official Journal on 24 July 2026 and in force from 27 July 2026. Replaced all "pending OJ publication" language with confirmed regulation number and dates. Updated compliance deadline table (Annex III standalone to 2 December 2027; Annex I embedded to 2 August 2028). Noted that Article 50 transparency obligations apply from 2 August 2026 as originally scheduled. Added two new prohibited practices effective 2 December 2026 (nudification AI and AI-generated CSAM). Updated header note, executive snapshot, EU jurisdiction section, admonition, What to Do guidance, and Side-by-Side Summary table.

- **`docs/safety-standards/ai-australian-legislation.md` (High):** Added two pre-legislative entries to Upcoming Legislative Reforms: (1) Federal/Victorian joint announcement on workplace surveillance and AI laws — proposed biometric monitoring protections, employer consultation obligations, and anti-discrimination rules for workers subject to AI management tools; (2) Victorian online safety and AI platform laws — proposed VCAT demasking powers and removal of the 10% psychiatric harm threshold for minor-plaintiff claims against AI platforms. Both marked clearly as pre-legislative (announced, not yet introduced to parliament).

- **`docs/business-resources/state-territory-ai-resources.md` (High):** Added two info admonitions under Victoria for the same pre-legislative announcements (workplace surveillance and AI laws; online safety and AI platform laws), consistent with the legislation page entries.

- **`docs/business-resources/ai-grants-funding-australia.md` (Medium):** Expanded the "AI Accelerator CRC (Future)" section into a full entry for CRC Round 28 (~$50M, announced 5 March 2026, opens 2027). Added the four AI priority areas, program structure detail (up to 10 years, consortium requirements), and updated the summary table row. Updated the info box at the top to reference Round 28 with key details.

### Flagged for manual action

- **Manual check required — consult.industry.gov.au ADM issues paper:** The URL `https://consult.industry.gov.au/automated-decision-making-ai-regulation-issues-paper` returned HTTP 403 during the researcher's scan. It is unclear whether this is a current 2026 Office of AI consultation or a legacy 2022 DISR document. Recommend direct browser access to confirm status. If confirmed as a new consultation with an open closing date, it may warrant Critical or High priority treatment.

- **Continue monitoring — National Cabinet August 2026:** Watch pm.gov.au and ministers' press releases for the specific National Cabinet meeting date and any published summary of the Australian Standards for AI framework.

- **Victoria bills — monitor for introduction:** Both the workplace surveillance/AI bill and the online safety/AI platforms bill should be monitored through the Victorian Parliament. Introduction before November 2026 state election is uncertain.

### Not actioned (by design)

- Australian Standards for AI (announced 15 July 2026): No new developments since the July 19 digest. National Cabinet consideration still expected August 2026.
- OAIC ADM transparency guidance: Consultation closed 15 June 2026; final guidance still expected September 2026. No change.
- Privacy Act Tranche 2: No bill. No change.
- VAISS / AI6: October 2025 AI6 version remains current. No change.
- All items in "No New Developments This Cycle" section of the digest.

## Source

Researcher digest: `agent-engine/research/weekly-digest-2026-07-26.md`

**Ready for review.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4DSBCJ19FdqMrVJF7LXHh)_