### PR TITLE
docs: Add South Australia's Royal Commission into Artificial Intelligence

### DIFF
--- a/docs/business-resources/state-territory-ai-resources.md
+++ b/docs/business-resources/state-territory-ai-resources.md
@@ -3,7 +3,7 @@ icon: lucide/map-pin
 title: "Australian Government AI Resources"
 description: "Official AI strategies, policies, assurance frameworks and statutory guidance from Australian federal, state and territory governments."
 keywords: "Australian government AI resources, federal AI policy, state AI policies, territory AI policies, government AI strategies, NAIC, OAIC, DTA, NSW AI policy, Victoria AI guidance, Queensland AI framework, SA AI resources, WA AI policy, Tasmania AI guidance, ACT AI policy, NT AI framework"
-last-reviewed: "2026-07-22"
+last-reviewed: "2026-08-17"
 review-cycle: "quarterly"
 og_description: "Comprehensive guide to AI resources published by Australian federal, state and territory governments"
 og_type: "article"
@@ -125,6 +125,15 @@ For a detailed overview of Australian AI legislation, see our [AI & Australian L
 - **[State Records SA — Artificial Intelligence & Information Management](https://www.archives.sa.gov.au/managing-information/Information-management/artificial-intelligence-and-information-management)** — recordkeeping obligations when developing/using AI.
 - **[Department for Education — EdChat (GenAI chatbot) overview](https://www.education.sa.gov.au/parents-and-families/curriculum-and-learning/ai/edchat)** — agency adoption example and usage guidance in schools.
 - **[State Budget — Digital Investment Fund: AI program](https://www.statebudget.sa.gov.au/our-budget/digital-capabilities)** — funding context to grow AI use in services.
+
+!!! info "South Australia — Royal Commission into Artificial Intelligence announced (10 August 2026)"
+    Premier Peter Malinauskas announced South Australia will establish a Royal Commission into Artificial Intelligence — described consistently across sources as the first Australian royal commission into AI — following his return from a US trip that included meetings at OpenAI, Anthropic and Apple. Terms of reference are pending.
+
+    The Commission is intended to examine AI's effects on work, the creative industries, education, public services and society, with the explicit goal of informing proactive state and national AI regulation rather than a retrospective/judicial inquiry. Three commissioners are expected to be appointed, reportedly with international expertise, at an estimated cost of around $3 million.
+
+    Terms of reference are expected within roughly six weeks of the announcement (by approximately late September 2026), with the Commission expected to commence 1 October 2026 and report to government by 1 July 2027. SA Opposition Leader Ashton Hurn has publicly questioned the cost and necessity, pointing to a prior parliamentary committee that produced 15 recommendations including a call for SA to work with the Commonwealth on nationally consistent AI laws. The SA Government has said implementation of any new SA AI regulations will not be delayed pending the Commission's findings.
+
+    SafeAI-Aus will update this entry once terms of reference and any public submissions process are confirmed. (Sources: [SBS News](https://www.sbs.com.au/news/article/australia-is-getting-its-first-major-inquiry-into-ai-its-starting-in-south-australia/xmpt3koiy), [InDaily](https://www.indailysa.com.au/news/just-in/2026/08/11/sa-govt-spearheads-ai-royal-commission-as-opposition-questions-cost), [Cyber Daily](https://www.cyberdaily.au/government/14025-artificial-intelligence-south-australian-premier-announces-royal-commission-into-ai); accessed 16 August 2026)
 
 !!! info "South Australia — Data Centre and AI Infrastructure Act proposed (June 2026)"
     The South Australian Government's June 2026 **Data Centre Strategy** commits to consulting on a proposed Act covering development approvals, energy, water, security and local benefits. The Act remains proposed; existing planning mechanisms and the proposed future legislation have different legal status.

--- a/docs/safety-standards/ai-australian-legislation.md
+++ b/docs/safety-standards/ai-australian-legislation.md
@@ -3,7 +3,7 @@ icon: lucide/flag
 title: "Current Legal Landscape for AI in Australia"
 description: "Overview of Australian laws relevant to AI adoption, including privacy, consumer protection, anti-discrimination and intellectual property."
 keywords: "AI legislation Australia, Australian AI law, AI privacy law, AI consumer law, AI discrimination law, AI intellectual property, AI legal compliance, Australian AI regulations, AI legal framework"
-last-reviewed: "2026-07-22"
+last-reviewed: "2026-08-17"
 review-cycle: "quarterly"
 og_description: "Comprehensive overview of current legislation applicable to AI adoption in Australian business"
 og_type: "article"
@@ -169,6 +169,9 @@ Australia's **IP laws**—covering copyright, patents, trademarks and design rig
 
 - ⚖️ **Consumer law — Competition and Consumer Amendment (Unfair Trading Practices) Act 2026 (assented 6 July 2026; commences 1 July 2027)**
   The Act received Royal Assent on 6 July 2026. Its technology-neutral prohibition may capture AI-enabled dark patterns and algorithmic manipulation where the statutory test is met. See the Australian Consumer Law section above for details. The Treasury review also found the existing ACL "fit for purpose" for AI; no broader dedicated AI consumer legislation is expected in the near term.
+
+- 🏛️ **South Australia — Royal Commission into Artificial Intelligence announced (10 August 2026)**
+  South Australia will establish Australia's first Royal Commission into AI — a state-level inquiry distinct from the federal Australian Standards for AI process above, examining AI's effects on work, education, public services and society. Terms of reference are expected by approximately late September 2026, with the Commission expected to commence 1 October 2026 and report to government by 1 July 2027. See the [South Australia section of state/territory resources](/business-resources/state-territory-ai-resources/#south-australia-sa) for full detail.
 
 !!! info "Government Policy and Guidance"
     For coverage of the National AI Plan, AI Safety Institute, DTA mandatory requirements, Senate Committee response and other government policy developments, see [Australian Government AI Policy and Frameworks](ai-government-policy-frameworks.md).


### PR DESCRIPTION
## Summary

Content updates based on the weekly researcher digest (16 August 2026).

### Changes made

- **`docs/business-resources/state-territory-ai-resources.md`** — added a new info box in the South Australia section covering the Royal Commission into Artificial Intelligence, announced 10 August 2026 (Australia's first). Covers commissioner count, ~$3M estimated cost, expected terms of reference (~late September 2026), planned start (1 October 2026), and report due date (1 July 2027). Flagged as "terms of reference pending" per the digest's recommendation. Updated `last-reviewed` to 2026-08-17.
- **`docs/safety-standards/ai-australian-legislation.md`** — added a brief cross-reference bullet under "Upcoming Legislative Reforms" noting the Royal Commission as a state-level inquiry distinct from the federal Australian Standards for AI process, linking back to the state/territory resources page. Updated `last-reviewed` to 2026-08-17.

### Flagged for manual action

- None this cycle — no new items required a new page or nav change.

### Not actioned (by design)

- Senate "Artificial Intelligence and Data Centres" inquiry (closes 1 September 2026): no new developments this cycle beyond the calendar advancing; already covered by prior content-update PRs.
- National Cabinet consideration of the Australian Standards for AI: still no confirmed meeting date; continue monitoring.
- Queensland ~$10M small/family business AI adoption program: held pending a dedicated program page/name, per prior cycles.
- Grants table changes: no AI-specific grant enters its 2-week closing window this cycle (ARC Discovery Indigenous 2027 and the Victoria Business Acceleration Fund both close within 2 weeks but neither meets the "AI-specific grant open to Australian businesses" trigger).
- All items in the digest's "Items Confirmed as No New Developments This Cycle" section.

### Follow-up

- The digest recommends checking for the Royal Commission's terms of reference and submissions process around late September 2026.
- The digest also flags a two-cycle-running `EGRESS_BLOCKED` pattern on Australian government domains during Researcher runs — recommend escalating to whoever manages the sandbox's network egress configuration.

## Source

Researcher digest: `agent-engine/research/weekly-digest-2026-08-16.md`

**Ready for review.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2tAZdiorffaHCnwuvXZTx)_