### PR TITLE
chore: Ignore local Airia agent files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ sitemap.xml
 
 # Local agent configuration and skills (not tracked)
 /.agents/
+.claude/airia-agents/
 /tmp/


### PR DESCRIPTION
## Summary

Ignore the machine-local `.claude/airia-agents/` directory so remote Airia agent artefacts cannot appear as repository changes.

## Impact

Local repository hygiene only. Published site content, navigation, URLs, analytics and deployment configuration are unchanged.

## Validation

- `zensical build --strict` completed successfully with Zensical 0.0.32
- Zensical emitted its existing notice that strict mode is currently unsupported
