### PR TITLE
chore: Remove deprecated Airia ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ sitemap.xml
 
 # Local agent configuration and skills (not tracked)
 /.agents/
-.claude/airia-agents/
 /tmp/


### PR DESCRIPTION
## Summary

- remove the redundant `.claude/airia-agents/` ignore rule
- complete the retirement of the deprecated Airia website agents

The two old local agent definition files were untracked and were deleted from this machine separately; this pull request contains only the repository-owned ignore-rule cleanup.

## Impact

No published site content, navigation, URLs, analytics or deployment behaviour changes.

## Validation

- repository scan found no remaining maintained Airia references
- `zensical build --strict` completed successfully with Zensical 0.0.32
- Zensical emitted its existing notice that strict mode is currently unsupported
